### PR TITLE
Add alias command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This guide explains usage of ALDB, compatibility requirements for Alloy models, 
 
 ## Getting Started
 
-1. Download the latest JAR from the [releases](https://github.com/WatForm/aldb/releases) or clone this repo and build ALDB following the instructions in the [contributing guildlines](./CONTRIBUTING.md).
+1. Download the latest JAR from the [releases](https://github.com/WatForm/aldb/releases) or clone this repo and build ALDB following the instructions in the [contributing guildlines](./CONTRIBUTING.md). Note that the master branch points to the latest, unstable, development version of ALDB.
 
 2. Run ALDB from the command line:
     ```sh
@@ -79,6 +79,7 @@ Refer to the worked example in this guide for a sample of a concrete Alloy model
 
 Command | Description
 -- | --
+alias | Control the set of aliases used
 alt | Select an alternate execution path
 break | Control the set of constraints used
 current | Display the current state
@@ -95,6 +96,13 @@ trace | Load a saved Alloy XML instance
 until | Run until constraints are met
 
 ### Detailed Descriptions
+
+#### alias
+The `alias [-c] [-l] [-rm] <alias> <predicate>` command allows for assigning a shorthand alias for a predicate. These aliases can be used when adding constraints via the `break` command.
+
+Specify the `-c` option to clear all aliases.
+Specify the `-l` option to list all current aliases.
+Specify the `-rm` option to remove an alias.
 
 #### alt
 The `alt [-r]` command switches between alternative execution paths in the current trace. Multiple unique states can be reached for a given path length; this command allows the user to explore all those states.

--- a/src/commands/AliasCommand.java
+++ b/src/commands/AliasCommand.java
@@ -1,0 +1,73 @@
+package commands;
+
+import simulation.AliasManager;
+import simulation.SimulationManager;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class AliasCommand extends Command {
+    private final static String RM_FLAG = "-rm";
+    private final static String L_FLAG = "-l";
+    private final static String C_FLAG = "-c";
+
+    public String getName() {
+        return CommandConstants.ALIAS_NAME;
+    }
+
+    public String getDescription() {
+        return CommandConstants.ALIAS_DESCRIPTION;
+    }
+
+    public String getHelp() {
+        return CommandConstants.ALIAS_HELP;
+    }
+
+    public String[] getShorthand() {
+        return CommandConstants.ALIAS_SHORTHAND;
+    }
+
+    public void execute(String[] input, SimulationManager simulationManager) {
+        if (input.length == 1) {
+            System.out.println(CommandConstants.ALIAS_HELP);
+            return;
+        }
+        String arg = input[1];
+
+        AliasManager am = simulationManager.getAliasManager();
+        if (arg.equals(RM_FLAG)) {
+            if (input.length != 3) {
+                System.out.println(CommandConstants.ALIAS_HELP);
+                return;
+            }
+            String alias = input[2];
+            if (!am.removeAlias(alias)) {
+                System.out.println(String.format(CommandConstants.ALIAS_DNE, alias));
+            }
+        } else if (arg.equals(L_FLAG)) {
+            System.out.println(am.getFormattedAliases());
+        } else if (arg.equals(C_FLAG)) {
+            am.clearAliases();
+        } else {
+            if (input.length < 3) {
+                System.out.println(CommandConstants.ALIAS_HELP);
+                return;
+            }
+
+            String predicate = String.join(" ", Arrays.copyOfRange(input, 2, input.length));
+            Matcher m = Pattern.compile(CommandConstants.CONSTRAINT_REGEX).matcher(predicate);
+
+            if (m.find()) {
+                // Only one predicate should be specified.
+                if (!m.hitEnd()) {
+                    System.out.println(CommandConstants.ALIAS_HELP);
+                    return;
+                }
+                predicate = m.group(1).replace("\"", "");
+                am.addAlias(arg, predicate);
+            }
+        }
+    }
+}

--- a/src/commands/BreakCommand.java
+++ b/src/commands/BreakCommand.java
@@ -1,5 +1,6 @@
 package commands;
 
+import simulation.AliasManager;
 import simulation.ConstraintManager;
 import simulation.SimulationManager;
 
@@ -66,8 +67,13 @@ public class BreakCommand extends Command {
             String allConstraints = String.join(" ", Arrays.copyOfRange(input, 1, input.length));
             Matcher m = Pattern.compile(CommandConstants.CONSTRAINT_REGEX).matcher(allConstraints);
 
+            AliasManager am = simulationManager.getAliasManager();
             while (m.find()) {
                 String constraint = m.group(1).replace("\"", "");
+
+                if (am.isAlias(constraint)) {
+                    // TODO (liangdrew)
+                }
 
                 if (simulationManager.validateConstraint(constraint)) {
                     cm.addConstraint(constraint);

--- a/src/commands/CommandConstants.java
+++ b/src/commands/CommandConstants.java
@@ -24,6 +24,17 @@ public class CommandConstants {
     public final static String UNTIL_FAILED = "Unable to find satisfying solution.";
     public final static String NO_MODEL_LOADED = "No model file specified.\nUse the \"load\" command.";
 
+    public final static String ALIAS_NAME = "alias";
+    public final static String ALIAS_DESCRIPTION = "Control the set of aliases used";
+    public final static String ALIAS_HELP = "Control the set of predicate aliases used.\n\n" +
+            "Usage:\n\n" +
+            "alias <alias> <predicate>  -- Add an alias\n" +
+            "alias -rm <alias>          -- Remove an alias\n" +
+            "alias -l                   -- List all aliases\n" +
+            "alias -c                   -- Clear aliases";
+    public final static String ALIAS_DNE = "Alias \"%s\" does not exist.";
+    public final static String[] ALIAS_SHORTHAND = {};
+
     public final static String CURRENT_NAME = "current";
     public final static String CURRENT_DESCRIPTION = "Display the current state";
     public final static String CURRENT_HELP = "Display the current state.\n\n" +

--- a/src/commands/CommandRegistry.java
+++ b/src/commands/CommandRegistry.java
@@ -4,6 +4,7 @@ public final class CommandRegistry {
     public final static Command NOT_FOUND = new NotFoundCommand();
     public final static Command EMPTY = new EmptyCommand();
     private final static Command[] commands = {
+        new AliasCommand(),
         new AltCommand(),
         new BreakCommand(),
         new CurrentCommand(),

--- a/src/simulation/AliasManager.java
+++ b/src/simulation/AliasManager.java
@@ -1,0 +1,42 @@
+package simulation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * AliasManager manages aliases for predicates which can be used as syntactic shortcuts.
+ */
+public class AliasManager {
+    private Map<String, String> aliases;
+    private final static String ALIAS_HEADER = "Alias";
+    private final static String PREDICATE_HEADER = "Predicate";
+
+    public AliasManager() {
+        aliases = new HashMap<>();
+    }
+
+    public boolean isAlias(String alias) {
+        return aliases.containsKey(alias);
+    }
+
+    public void addAlias(String alias, String predicate) {
+        aliases.put(alias, predicate);
+    }
+
+    public boolean removeAlias(String alias) {
+        return aliases.remove(alias) != null;
+    }
+
+    public void clearAliases() {
+        aliases.clear();
+    }
+
+    public String getFormattedAliases() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("\n%-16s%s\n", ALIAS_HEADER, PREDICATE_HEADER));
+        for (String alias : aliases.keySet()) {
+            sb.append(String.format("%-16s%s\n", alias, aliases.get(alias)));
+        }
+        return sb.toString();
+    }
+}

--- a/src/simulation/SimulationManager.java
+++ b/src/simulation/SimulationManager.java
@@ -36,6 +36,7 @@ public class SimulationManager {
     private StatePath statePath;
     private StateGraph stateGraph;
     private Stack<A4Solution> activeSolutions;
+    private AliasManager aliasManager;
     private ConstraintManager constraintManager;
 
     private boolean traceMode;
@@ -47,6 +48,7 @@ public class SimulationManager {
         persistentParsingConf = new ParsingConf();
         embeddedParsingConf = null;
         activeSolutions = new Stack<>();
+        aliasManager = new AliasManager();
         constraintManager = new ConstraintManager();
 
         traceMode = false;
@@ -430,6 +432,10 @@ public class SimulationManager {
 
     public String getCurrentStateDiffString() {
         return statePath.getCurNode().getDiffString(statePath.getPrevNode());
+    }
+
+    public AliasManager getAliasManager() {
+        return aliasManager;
     }
 
     public ConstraintManager getConstraintManager() {

--- a/test/commands/TestAliasCommand.java
+++ b/test/commands/TestAliasCommand.java
@@ -1,0 +1,143 @@
+package commands;
+
+import commands.AliasCommand;
+import simulation.AliasManager;
+import simulation.SimulationManager;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+
+public class TestAliasCommand extends TestCommand {
+    private final AliasCommand aliasCommand = new AliasCommand();
+    private final SimulationManager simulationManager = mock(SimulationManager.class);
+    private final AliasManager am = mock(AliasManager.class);
+
+    @Test
+    public void testGetName() {
+        assertEquals(aliasCommand.getName(), CommandConstants.ALIAS_NAME);
+    }
+
+    @Test
+    public void testGetDescription() {
+        assertEquals(aliasCommand.getDescription(), CommandConstants.ALIAS_DESCRIPTION);
+    }
+
+    @Test
+    public void testGetHelp() {
+        assertEquals(aliasCommand.getHelp(), CommandConstants.ALIAS_HELP);
+    }
+
+    @Test
+    public void testGetShorthand() {
+        assertEquals(aliasCommand.getShorthand(), CommandConstants.ALIAS_SHORTHAND);
+    }
+
+    @Test
+    public void testRequiresFile() {
+        assertFalse(aliasCommand.requiresFile());
+    }
+
+    @Test
+    public void testExecute_rm() {
+        setupStreams();
+        when(simulationManager.getAliasManager()).thenReturn(am);
+        when(am.removeAlias(anyString())).thenReturn(true);
+
+        String[] input = {"alias", "-rm", "p1"};
+        aliasCommand.execute(input, simulationManager);
+        verify(am).removeAlias("p1");
+        restoreStreams();
+    }
+
+    @Test
+    public void testExecute_rm_invalid() {
+        setupStreams();
+        String[] input = {"alias", "-rm"};
+        String errMsg = CommandConstants.ALIAS_HELP + "\n";
+        aliasCommand.execute(input, simulationManager);
+        assertEquals(errMsg, outContent.toString());
+        restoreStreams();
+    }
+
+    @Test
+    public void testExecute_rm_alias_dne() {
+        setupStreams();
+        when(simulationManager.getAliasManager()).thenReturn(am);
+        String[] input = {"alias", "-rm", "foo"};
+        String errMsg = String.format(CommandConstants.ALIAS_DNE, "foo") + "\n";
+        aliasCommand.execute(input, simulationManager);
+        assertEquals(errMsg, outContent.toString());
+        restoreStreams();
+    }
+
+    @Test
+    public void testExecute_l() {
+        setupStreams();
+        String res = "foo";
+        when(simulationManager.getAliasManager()).thenReturn(am);
+        when(am.getFormattedAliases()).thenReturn(res);
+
+        String[] input = {"alias", "-l"};
+        aliasCommand.execute(input, simulationManager);
+        verify(am).getFormattedAliases();
+        assertEquals(res + "\n", outContent.toString());
+        restoreStreams();
+    }
+
+    @Test
+    public void testExecute_c() {
+        setupStreams();
+        when(simulationManager.getAliasManager()).thenReturn(am);
+        String[] input = {"alias", "-c"};
+        aliasCommand.execute(input, simulationManager);
+        verify(am).clearAliases();
+        restoreStreams();
+    }
+
+    @Test
+    public void testExecute_addAlias() {
+        setupStreams();
+        when(simulationManager.isInitialized()).thenReturn(true);
+        when(simulationManager.getAliasManager()).thenReturn(am);
+
+        String[] input = {"alias", "p1", "a=b"};
+        String[] input2 = {"alias", "p2", "\"c = d\""};
+        aliasCommand.execute(input, simulationManager);
+        verify(am).addAlias("p1", "a=b");
+        aliasCommand.execute(input2, simulationManager);
+        verify(am).addAlias("p2", "c = d");
+        restoreStreams();
+    }
+
+    @Test
+    public void testExecute_addAlias_no_predicate() {
+        setupStreams();
+        String[] input = {"alias", "p1"};
+        String errMsg = CommandConstants.ALIAS_HELP + "\n";
+        aliasCommand.execute(input, simulationManager);
+        assertEquals(errMsg, outContent.toString());
+        restoreStreams();
+    }
+
+    @Test
+    public void testExecute_addAlias_multiple_pred() {
+        setupStreams();
+        String[] input = {"alias", "p1", "a=b", "c=d"};
+        String errMsg = CommandConstants.ALIAS_HELP + "\n";
+        aliasCommand.execute(input, simulationManager);
+        assertEquals(errMsg, outContent.toString());
+        restoreStreams();
+    }
+
+    @Test
+    public void testExecute_help() {
+        setupStreams();
+        String[] input = {"alias"};
+        String errMsg = CommandConstants.ALIAS_HELP + "\n";
+        aliasCommand.execute(input, simulationManager);
+        assertEquals(errMsg, outContent.toString());
+        restoreStreams();
+    }
+}

--- a/test/commands/TestBreakCommand.java
+++ b/test/commands/TestBreakCommand.java
@@ -1,6 +1,7 @@
 package commands;
 
 import commands.BreakCommand;
+import simulation.AliasManager;
 import simulation.ConstraintManager;
 import simulation.SimulationManager;
 
@@ -12,6 +13,7 @@ import org.junit.Test;
 public class TestBreakCommand extends TestCommand {
     private final BreakCommand breakCommand = new BreakCommand();
     private final SimulationManager simulationManager = mock(SimulationManager.class);
+    private final AliasManager am = mock(AliasManager.class);
     private final ConstraintManager cm = mock(ConstraintManager.class);
 
     @Test
@@ -76,6 +78,7 @@ public class TestBreakCommand extends TestCommand {
     @Test
     public void testExecute_addConstraint() {
         when(simulationManager.isInitialized()).thenReturn(true);
+        when(simulationManager.getAliasManager()).thenReturn(am);
         when(simulationManager.getConstraintManager()).thenReturn(cm);
         when(simulationManager.validateConstraint(anyString())).thenReturn(true);
 
@@ -133,6 +136,7 @@ public class TestBreakCommand extends TestCommand {
         setupStreams();
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.validateConstraint(anyString())).thenReturn(false);
+        when(simulationManager.getAliasManager()).thenReturn(am);
         String[] input = {"break", "invalid"};
         String errMsg = String.format(CommandConstants.INVALID_CONSTRAINT, input[1]) + "\n";
         breakCommand.execute(input, simulationManager);

--- a/test/commands/TestHelpCommand.java
+++ b/test/commands/TestHelpCommand.java
@@ -13,6 +13,7 @@ public class TestHelpCommand extends TestCommand {
     private final String help_all_commands = String.join("\n",
         "Available commands:",
         "",
+        "alias          -- Control the set of aliases used",
         "alt            -- Select an alternate execution path",
         "break          -- Control the set of constraints used",
         "current        -- Display the current state",

--- a/test/simulation/TestAliasManager.java
+++ b/test/simulation/TestAliasManager.java
@@ -1,0 +1,71 @@
+package simulation;
+
+import simulation.AliasManager;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.Test;
+
+public class TestAliasManager {
+    @Test
+    public void testAddAlias() {
+        AliasManager am = new AliasManager();
+        String alias = "p1";
+        String alias2 = "p2";
+        String predicate = "a=b";
+
+        am.addAlias(alias, predicate);
+        assertTrue(am.isAlias(alias));
+        assertFalse(am.isAlias(alias2));
+
+        am.addAlias(alias2, predicate);
+        assertTrue(am.isAlias(alias));
+        assertTrue(am.isAlias(alias2));
+
+        // Test overwriting.
+        String predicate2 = "c=d";
+        am.addAlias(alias, predicate2);
+        assertTrue(am.isAlias(alias));
+        assertTrue(am.isAlias(alias2));
+    }
+
+    @Test
+    public void testRemoveAlias() {
+        AliasManager am = new AliasManager();
+        String alias = "p1";
+        String predicate = "a=b";
+
+        assertFalse(am.removeAlias(alias));
+        am.addAlias(alias, predicate);
+        assertTrue(am.removeAlias(alias));
+        assertFalse(am.isAlias(alias));
+        assertFalse(am.removeAlias(alias));
+    }
+
+    @Test
+    public void testClearAliases() {
+        AliasManager am = new AliasManager();
+        String alias = "p1";
+        String alias2 = "p2";
+        String predicate = "a=b";
+
+        am.addAlias(alias, predicate);
+        am.addAlias(alias2, predicate);
+        am.clearAliases();
+        assertFalse(am.isAlias(alias));
+        assertFalse(am.isAlias(alias2));
+    }
+
+    @Test
+    public void testGetFormattedAliases() {
+        AliasManager am = new AliasManager();
+        String alias = "p1";
+        String alias2 = "p2";
+        String predicate = "a=b";
+
+        am.addAlias(alias, predicate);
+        am.addAlias(alias2, predicate);
+        String expected = "\nAlias           Predicate\np1              a=b\np2              a=b\n";
+        assertEquals(expected, am.getFormattedAliases());
+    }
+}


### PR DESCRIPTION
The `alias` command can be used to define shorthand aliases for predicates (to be used by the break command, for example).

Usage:
```
(aldb) alias p1 a=b
(aldb) alias p2 "c = d"
(aldb) alias -l

Alias           Predicate
p1              a=b
p2              c = d

(aldb) alias p1 e=f
(aldb) alias -l

Alias           Predicate
p1              e=f
p2              c = d

(aldb) alias -rm p3
Alias "p3" does not exist.
(aldb) alias -rm p2
(aldb) alias -c
(aldb) alias -l

Alias           Predicate

(aldb) alias p1 a=b c=d
Control the set of predicate aliases used.

Usage:

alias <alias> <predicate>  -- Add an alias
alias -rm <alias>          -- Remove an alias
alias -l                   -- List all aliases
alias -c                   -- Clear aliases
```

Checking for aliases in the `break` command and associated tests will follow in another PR.

Closes #1.