### PR TITLE
Always print fields in set notation

### DIFF
--- a/src/commands/ScopeCommand.java
+++ b/src/commands/ScopeCommand.java
@@ -26,27 +26,34 @@ public class ScopeCommand extends Command {
         }
 
         if (input.length == 1) {
-            System.out.println();
             Map<String, List<String>> scopes = simulationManager.getScopes();
-            for (String label : scopes.keySet()) {
-                StringBuilder sb = new StringBuilder();
-                sb.append(String.format("%s: %s ", label, AlloyConstants.BLOCK_INITIALIZER));
-                sb.append(String.format("%s %s", String.join(", ", scopes.get(label)), AlloyConstants.BLOCK_TERMINATOR));
-                System.out.println(sb.toString());
-            }
-            System.out.println();
+            System.out.println(stringForScopeSet(scopes));
             return;
         }
         String sigName = input[1];
         List<String> scope = simulationManager.getScopeForSig(sigName);
+        System.out.println(stringForSig(scope));
+    }
+
+    private String stringForScopeSet(Map<String, List<String>> scopes) {
+        StringBuilder sb = new StringBuilder();
+        for (String label : scopes.keySet()) {
+            sb.append(String.format("\n%s: %s ", label, AlloyConstants.BLOCK_INITIALIZER));
+            sb.append(String.format("%s %s", String.join(", ", scopes.get(label)), AlloyConstants.BLOCK_TERMINATOR));
+        }
+        sb.append("\n");
+        return sb.toString();
+    }
+
+    private String stringForSig(List<String> scope) {
         if (scope == null) {
-            System.out.println(CommandConstants.SIG_NOT_FOUND);
-            return;
+            return CommandConstants.SIG_NOT_FOUND;
         }
-        System.out.println();
-        for (String s : scope) {
-            System.out.println(s);
-        }
-        System.out.println();
+        return String.format(
+            "\n%s %s %s\n",
+            AlloyConstants.BLOCK_INITIALIZER,
+            String.join(", ", scope),
+            AlloyConstants.BLOCK_TERMINATOR
+        );
     }
 }

--- a/src/commands/ScopeCommand.java
+++ b/src/commands/ScopeCommand.java
@@ -27,15 +27,15 @@ public class ScopeCommand extends Command {
 
         if (input.length == 1) {
             Map<String, List<String>> scopes = simulationManager.getScopes();
-            System.out.println(stringForScopeSet(scopes));
+            System.out.println(formattedScopes(scopes));
             return;
         }
         String sigName = input[1];
         List<String> scope = simulationManager.getScopeForSig(sigName);
-        System.out.println(stringForSig(scope));
+        System.out.println(formattedScope(scope));
     }
 
-    private String stringForScopeSet(Map<String, List<String>> scopes) {
+    private String formattedScopes(Map<String, List<String>> scopes) {
         StringBuilder sb = new StringBuilder();
         for (String label : scopes.keySet()) {
             sb.append(String.format("\n%s: %s ", label, AlloyConstants.BLOCK_INITIALIZER));
@@ -45,7 +45,7 @@ public class ScopeCommand extends Command {
         return sb.toString();
     }
 
-    private String stringForSig(List<String> scope) {
+    private String formattedScope(List<String> scope) {
         if (scope == null) {
             return CommandConstants.SIG_NOT_FOUND;
         }

--- a/src/simulation/SimulationManager.java
+++ b/src/simulation/SimulationManager.java
@@ -18,10 +18,11 @@ import java.io.IOException;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
 import java.util.Stack;
+import java.util.TreeMap;
 
 import org.yaml.snakeyaml.error.YAMLException;
 
@@ -29,7 +30,7 @@ public class SimulationManager {
     private File alloyModelFile;
     private String alloyModelString;
     private String alloyInitString;
-    private Map<String, List<String>> scopes;
+    private SortedMap<String, List<String>> scopes;
     private ParsingConf persistentParsingConf;  // Set by setconf - used across multiple models.
     private ParsingConf embeddedParsingConf;  // Set by load - used for the current model only.
     private SigData stateSigData;
@@ -41,7 +42,7 @@ public class SimulationManager {
     private boolean traceMode;
 
     public SimulationManager() {
-        scopes = new HashMap<>();
+        scopes = new TreeMap<>();
         statePath = new StatePath();
         stateGraph = new StateGraph();
         persistentParsingConf = new ParsingConf();

--- a/src/state/StateNode.java
+++ b/src/state/StateNode.java
@@ -77,16 +77,12 @@ public class StateNode {
             return "Property not found.";
         }
 
-        StringBuilder sb = new StringBuilder();
-        sb.append(
-            String.format(
-                "\n%s %s %s\n",
-                AlloyConstants.BLOCK_INITIALIZER,
-                String.join(", ", state.get(property)),
-                AlloyConstants.BLOCK_TERMINATOR
-            )
+        return String.format(
+            "\n%s %s %s\n",
+            AlloyConstants.BLOCK_INITIALIZER,
+            String.join(", ", state.get(property)),
+            AlloyConstants.BLOCK_TERMINATOR
         );
-        return sb.toString();
     }
 
     /**

--- a/src/state/StateNode.java
+++ b/src/state/StateNode.java
@@ -78,10 +78,14 @@ public class StateNode {
         }
 
         StringBuilder sb = new StringBuilder();
-        sb.append("\n");
-        for (String value : state.get(property)) {
-            sb.append(String.format("%s\n", value));
-        }
+        sb.append(
+            String.format(
+                "\n%s %s %s\n",
+                AlloyConstants.BLOCK_INITIALIZER,
+                String.join(", ", state.get(property)),
+                AlloyConstants.BLOCK_TERMINATOR
+            )
+        );
         return sb.toString();
     }
 

--- a/test/commands/TestScopeCommand.java
+++ b/test/commands/TestScopeCommand.java
@@ -58,7 +58,22 @@ public class TestScopeCommand extends TestCommand {
         String[] input = {"scope", "sig"};
         scope.execute(input, simulationManager);
         verify(simulationManager).getScopeForSig("sig");
-        String msg = "\nscope\n\n";
+        String msg = "\n{ scope }\n\n";
+        assertEquals(msg, outContent.toString());
+        restoreStreams();
+    }
+
+    @Test
+    public void testExecute_sigInputEmpty() {
+        setupStreams();
+        List<String> res = new ArrayList<>();
+        when(simulationManager.isInitialized()).thenReturn(true);
+        when(simulationManager.getScopeForSig(anyString())).thenReturn(res);
+
+        String[] input = {"scope", "sig"};
+        scope.execute(input, simulationManager);
+        verify(simulationManager).getScopeForSig("sig");
+        String msg = "\n{  }\n\n";
         assertEquals(msg, outContent.toString());
         restoreStreams();
     }

--- a/test/state/TestStateNode.java
+++ b/test/state/TestStateNode.java
@@ -69,14 +69,22 @@ public class TestStateNode {
     public void testStringForProperty() {
         String expected = String.join("\n",
             "",
-            "string1",
-            "string2",
-            "string3",
+            "{ string1, string2, string3 }",
             ""
         );
         stateNode.addValueToField("f", "string1");
         stateNode.addValueToField("f", "string2");
         stateNode.addValueToField("f", "string3");
+        assertEquals(expected, stateNode.stringForProperty("f"));
+    }
+
+    @Test
+    public void testStringForProperty_empty() {
+        String expected = String.join("\n",
+            "",
+            "{  }",
+            ""
+        );
         assertEquals(expected, stateNode.stringForProperty("f"));
     }
 


### PR DESCRIPTION
closes #3 
Uses set notation with curly brackets when outputting a property's elements. 
```
(aldb) c far

{  }

(aldb) c near

{ Chicken, Farmer, Fox, Grain }
```