### PR TITLE
Store StateNode fields in sorted order

### DIFF
--- a/src/state/StateNode.java
+++ b/src/state/StateNode.java
@@ -7,16 +7,17 @@ import alloy.SigData;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
 
 /**
  * StateNode represents a single execution state of an Alloy transition system.
  */
 public class StateNode {
     private List<StateNode> steps; // outgoing edges (states that can be stepped to from this state)
-    private Map<String, List<String>> state; // the state that this node represents
+    private SortedMap<String, List<String>> state; // the state that this node represents
     private int id;
     private ParsingConf parsingConf;
     private SigData sigData;
@@ -25,7 +26,7 @@ public class StateNode {
         sigData = data;
         parsingConf = conf;
         steps = new ArrayList<>();
-        state = new HashMap<>();
+        state = new TreeMap<>();
 
         for (String field : sigData.getFields()) {
             state.put(field, new ArrayList<>());
@@ -142,8 +143,6 @@ public class StateNode {
             if (vals == null) {
                 break;
             }
-            Collections.sort(vals);
-            Collections.sort(otherVals);
             if (!vals.equals(otherVals)) {
                 return false;
             }

--- a/src/state/StateNode.java
+++ b/src/state/StateNode.java
@@ -7,10 +7,10 @@ import alloy.SigData;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.TreeMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
+import java.util.TreeMap;
 
 /**
  * StateNode represents a single execution state of an Alloy transition system.
@@ -143,6 +143,8 @@ public class StateNode {
             if (vals == null) {
                 break;
             }
+            Collections.sort(vals);
+            Collections.sort(otherVals);
             if (!vals.equals(otherVals)) {
                 return false;
             }

--- a/src/state/StateNode.java
+++ b/src/state/StateNode.java
@@ -8,7 +8,6 @@ import alloy.SigData;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -95,7 +94,7 @@ public class StateNode {
             return toString();
         }
 
-        Map<String, List<String>> otherState = other.state;
+        SortedMap<String, List<String>> otherState = other.state;
 
         StringBuilder sb = new StringBuilder();
         for (String key : state.keySet()) {
@@ -158,7 +157,7 @@ public class StateNode {
      */
     public String getAlloyInitString() {
         StringBuilder sb = new StringBuilder();
-        for (Map.Entry<String, List<String>> entry : state.entrySet()) {
+        for (SortedMap.Entry<String, List<String>> entry : state.entrySet()) {
             List<String> vals = entry.getValue();
             StringBuilder alloyFormattedValsBuilder = new StringBuilder();
             String prefix = "";

--- a/test/simulation/TestSimulationManager.java
+++ b/test/simulation/TestSimulationManager.java
@@ -164,27 +164,27 @@ public class TestSimulationManager {
         );
         String expectedCurrentState = String.join("\n",
             "",
-            "mode: { sitting }",
-            "players: { Player_0, Player_1, Player_2, Player_3 }",
             "chairs: { Chair_0, Chair_1, Chair_2 }",
+            "mode: { sitting }",
             "occupied: { Chair_0->Player_2, Chair_1->Player_1, Chair_2->Player_0 }",
+            "players: { Player_0, Player_1, Player_2, Player_3 }",
             ""
         );
         String expectedHistory = String.join("\n",
             "",
             "(-2)",
             "----",
-            "mode: { start }",
-            "players: { Player_0, Player_1, Player_2, Player_3 }",
             "chairs: { Chair_0, Chair_1, Chair_2 }",
+            "mode: { start }",
             "occupied: {  }",
+            "players: { Player_0, Player_1, Player_2, Player_3 }",
             "",
             "(-1)",
             "----",
-            "mode: { walking }",
-            "players: { Player_0, Player_1, Player_2, Player_3 }",
             "chairs: { Chair_0, Chair_1, Chair_2 }",
+            "mode: { walking }",
             "occupied: {  }",
+            "players: { Player_0, Player_1, Player_2, Player_3 }",
             ""
         );
 

--- a/test/state/TestStateNode.java
+++ b/test/state/TestStateNode.java
@@ -182,8 +182,8 @@ public class TestStateNode {
     private Sig createNewSig() {
         Sig sigA = new Sig.PrimSig("A");
         Sig sigB = new Sig.PrimSig("B");
-        Sig.Field f1 = sigA.addField("f", sigB.lone_arrow_lone(sigB));
-        Sig.Field f2 = sigA.addField("g", sigB);
+        Sig.Field f1 = sigA.addField("g", sigB);
+        Sig.Field f2 = sigA.addField("f", sigB.lone_arrow_lone(sigB));
         return sigA;
     }
 }


### PR DESCRIPTION
closes #5 
State names are now shown in alphabetical order by using a treeMap instead of hashMap:
```
chairs: { Chair_0, Chair_1, Chair_2 }
mode: { start }
occupied: {  }
players: { Player_0, Player_1, Player_2, Player_3 }
```