### PR TITLE
Check if entered constraints are aliases

### DIFF
--- a/src/commands/BreakCommand.java
+++ b/src/commands/BreakCommand.java
@@ -72,7 +72,7 @@ public class BreakCommand extends Command {
                 String constraint = m.group(1).replace("\"", "");
 
                 if (am.isAlias(constraint)) {
-                    // TODO (liangdrew)
+                    constraint = am.getPredicate(constraint);
                 }
 
                 if (simulationManager.validateConstraint(constraint)) {

--- a/src/simulation/AliasManager.java
+++ b/src/simulation/AliasManager.java
@@ -31,6 +31,10 @@ public class AliasManager {
         aliases.clear();
     }
 
+    public String getPredicate(String alias) {
+        return aliases.get(alias);
+    }
+
     public String getFormattedAliases() {
         StringBuilder sb = new StringBuilder();
         sb.append(String.format("\n%-16s%s\n", ALIAS_HEADER, PREDICATE_HEADER));

--- a/test/commands/TestBreakCommand.java
+++ b/test/commands/TestBreakCommand.java
@@ -90,6 +90,23 @@ public class TestBreakCommand extends TestCommand {
     }
 
     @Test
+    public void testExecute_addAliasedConstraint() {
+        when(simulationManager.isInitialized()).thenReturn(true);
+        when(simulationManager.getAliasManager()).thenReturn(am);
+        when(simulationManager.getConstraintManager()).thenReturn(cm);
+        when(simulationManager.validateConstraint(anyString())).thenReturn(true);
+
+        String alias = "p1";
+        String predicate = "a=b";
+        when(am.isAlias(alias)).thenReturn(true);
+        when(am.getPredicate(alias)).thenReturn(predicate);
+        String[] input = {"break", alias};
+
+        breakCommand.execute(input, simulationManager);
+        verify(cm).addConstraint(predicate);
+    }
+
+    @Test
     public void testExecute_help() {
         setupStreams();
         String[] input = {"break"};

--- a/test/simulation/TestAliasManager.java
+++ b/test/simulation/TestAliasManager.java
@@ -16,17 +16,23 @@ public class TestAliasManager {
 
         am.addAlias(alias, predicate);
         assertTrue(am.isAlias(alias));
+        assertEquals(predicate, am.getPredicate(alias));
+        assertEquals(null, am.getPredicate(alias2));
         assertFalse(am.isAlias(alias2));
 
         am.addAlias(alias2, predicate);
         assertTrue(am.isAlias(alias));
         assertTrue(am.isAlias(alias2));
+        assertEquals(predicate, am.getPredicate(alias));
+        assertEquals(predicate, am.getPredicate(alias2));
 
         // Test overwriting.
         String predicate2 = "c=d";
-        am.addAlias(alias, predicate2);
+        am.addAlias(alias2, predicate2);
         assertTrue(am.isAlias(alias));
         assertTrue(am.isAlias(alias2));
+        assertEquals(predicate, am.getPredicate(alias));
+        assertEquals(predicate2, am.getPredicate(alias2));
     }
 
     @Test


### PR DESCRIPTION
Example:

```
(aldb) alias a far=Object
(aldb) alias -l

Alias           Predicate
a               far=Object

(aldb) break a
(aldb) break -l

Num     Constraint
1       far=Object

(aldb) until

far: { Chicken, Farmer, Fox, Grain }
near: {  }

(aldb)
```

Closes #7.