### PR TITLE
Simplify creation of temp model file

### DIFF
--- a/src/alloy/AlloyUtils.java
+++ b/src/alloy/AlloyUtils.java
@@ -124,24 +124,6 @@ public class AlloyUtils {
         );
     }
 
-    /**
-     * createTmpFile creates a new file in the same directory as the given file.
-     * It then writes the contents into the new file and will delete it once the
-     * JVM terminates. This is required in Alloy to support models with user
-     * created imports as it can only find the submodules in the original file path.
-     * @param String, File
-     * @return File
-     */
-    public static File createTmpFile(String contents, File file) throws IOException {
-        String filename = "_tmp_" + file.getName();
-        File tmpFile = new File(file.getParentFile(), filename);
-
-        writeToFile(contents, tmpFile);
-        tmpFile.deleteOnExit();
-
-        return tmpFile;
-    }
-
     public static void writeToFile(String contents, File file) throws IOException {
         BufferedWriter writer = new BufferedWriter(new FileWriter(file));
         writer.write(contents);

--- a/src/commands/LoadCommand.java
+++ b/src/commands/LoadCommand.java
@@ -46,6 +46,8 @@ public class LoadCommand extends Command {
         System.out.printf(CommandConstants.READING_MODEL, filename);
 
         String tempModelFilename = TEMP_FILENAME_PREFIX + file.getName();
+        // Note that the temp model file must be created in the same directory as the input model
+        // in order for Alloy to correctly find imported submodules.
         File tempModelFile = new File(file.getParentFile(), tempModelFilename);
         tempModelFile.deleteOnExit();
 

--- a/src/commands/LoadCommand.java
+++ b/src/commands/LoadCommand.java
@@ -3,11 +3,13 @@ package commands;
 import alloy.AlloyUtils;
 import simulation.SimulationManager;
 
-import java.io.IOException;
 import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
 public class LoadCommand extends Command {
+    private final static String TEMP_FILENAME_PREFIX = "_tmp_";
+
     public String getName() {
         return CommandConstants.LOAD_NAME;
     }
@@ -43,23 +45,18 @@ public class LoadCommand extends Command {
 
         System.out.printf(CommandConstants.READING_MODEL, filename);
 
-        String inputFileContents;
-        try {
-            inputFileContents = AlloyUtils.readFromFile(file);
-        } catch (IOException e) {
-            System.out.println(CommandConstants.FAILED_TO_READ_FILE);
-            return;
-        }
+        String tempModelFilename = TEMP_FILENAME_PREFIX + file.getName();
+        File tempModelFile = new File(file.getParentFile(), tempModelFilename);
+        tempModelFile.deleteOnExit();
 
-        File tmpModelFile;
         try {
-            tmpModelFile = AlloyUtils.createTmpFile(inputFileContents, file);
-        } catch (IOException e) {
+            Files.copy(file.toPath(), tempModelFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        } catch (Exception e) {
             System.out.println(CommandConstants.TMP_FILE_ERROR);
             return;
         }
 
-        if (simulationManager.initializeWithModel(tmpModelFile)) {
+        if (simulationManager.initializeWithModel(tempModelFile)) {
             System.out.println(CommandConstants.DONE);
         }
     }

--- a/test/alloy/TestAlloyUtils.java
+++ b/test/alloy/TestAlloyUtils.java
@@ -172,30 +172,6 @@ public class TestAlloyUtils {
         assertEquals(expected, AlloyUtils.getConcreteSigsDefinition(sigScopes));
     }
 
-    @Test
-    public void testCreateTmpFile() throws IOException {
-        File file = new File("/tmp/sample.als");
-        String contents = "Hello World";
-        file.createNewFile();
-        File tmpFile = AlloyUtils.createTmpFile(contents, file);
-        assertTrue(tmpFile.exists());
-        assertEquals("_tmp_" + file.getName(), tmpFile.getName());
-        assertEquals(file.getParent(), tmpFile.getParent());
-        file.delete();
-    }
-
-    @Test
-    public void testCreateTmpFile_nullParentPath() throws IOException {
-        File file = new File("sample.als");
-        String contents = "Hello World";
-        file.createNewFile();
-        File tmpFile = AlloyUtils.createTmpFile(contents, file);
-        assertTrue(tmpFile.exists());
-        assertEquals("_tmp_" + file.getName(), tmpFile.getName());
-        assertEquals(file.getParent(), tmpFile.getParent());
-        file.delete();
-    }
-
     private Sig createNewSig() {
         Sig sigA = new Sig.PrimSig("A");
         Sig sigB = new Sig.PrimSig("B");


### PR DESCRIPTION
Instead of reading the input model all into memory and writing it back to disk, we can leverage the `Files.copy` API.

Closes #13.