### PR TITLE
Fix trace-after-load bug

### DIFF
--- a/src/simulation/SimulationManager.java
+++ b/src/simulation/SimulationManager.java
@@ -191,6 +191,16 @@ public class SimulationManager {
             return false;
         }
 
+        evaluateScopes(sol);
+
+        Sig stateSig = AlloyInterface.getSigFromA4Solution(sol, getParsingConf().getStateSigName());
+        if (stateSig == null) {
+            System.out.printf("error. Sig %s not found.\n", getParsingConf().getStateSigName());
+            return false;
+        }
+
+        stateSigData = new SigData(stateSig);
+
         List<StateNode> stateNodes = getStateNodesForA4Solution(sol);
         if (stateNodes.isEmpty()) {
             return false;

--- a/test/e2e/TestScenarios.java
+++ b/test/e2e/TestScenarios.java
@@ -82,6 +82,68 @@ public class TestScenarios {
     }
 
     @Test
+    public void testTraceFGS() throws Exception {
+        runALDB(
+            "setconf traces/fgs_conf.yml",
+            "trace traces/fgs_counterexample.xml",
+            "step",
+            "step"
+        );
+        assertOutput(
+            "Setting parsing options from traces/fgs_conf.yml...done.",
+            "Reading trace from traces/fgs_counterexample.xml...done.",
+            "",
+            "FlightModes_NAV_Selected: { boolean/True }",
+            "stable: { boolean/False }",
+            "",
+            "",
+            "FlightModes_ALTSEL_Selected: { boolean/True }",
+            "FlightModes_FD_On: { boolean/True }",
+            "FlightModes_HDG_Switch_Pressed: { boolean/False }",
+            "FlightModes_Modes_On: { boolean/True }",
+            "FlightModes_NAV_Capture_Condition_Met: { boolean/True }",
+            "FlightModes_NAV_Selected: { boolean/False }",
+            "FlightModes_NAV_Switch_Pressed: { boolean/False }",
+            "FlightModes_Pilot_Flying_Transfer: { boolean/True }",
+            "FlightModes_Selected_NAV_Frequency_Changed: { boolean/False }",
+            "stable: { boolean/True }",
+            ""
+        );
+    }
+
+    @Test
+    public void testTraceFGS_afterLoad() throws Exception {
+        runALDB(
+            "load models/switch.als",
+            "setconf traces/fgs_conf.yml",
+            "trace traces/fgs_counterexample.xml",
+            "step",
+            "step"
+        );
+        assertOutput(
+            "Reading model from models/switch.als...done.",
+            "Setting parsing options from traces/fgs_conf.yml...done.",
+            "Reading trace from traces/fgs_counterexample.xml...done.",
+            "",
+            "FlightModes_NAV_Selected: { boolean/True }",
+            "stable: { boolean/False }",
+            "",
+            "",
+            "FlightModes_ALTSEL_Selected: { boolean/True }",
+            "FlightModes_FD_On: { boolean/True }",
+            "FlightModes_HDG_Switch_Pressed: { boolean/False }",
+            "FlightModes_Modes_On: { boolean/True }",
+            "FlightModes_NAV_Capture_Condition_Met: { boolean/True }",
+            "FlightModes_NAV_Selected: { boolean/False }",
+            "FlightModes_NAV_Switch_Pressed: { boolean/False }",
+            "FlightModes_Pilot_Flying_Transfer: { boolean/True }",
+            "FlightModes_Selected_NAV_Frequency_Changed: { boolean/False }",
+            "stable: { boolean/True }",
+            ""
+        );
+    }
+
+    @Test
     public void testLoadIdempotent_noEmbeddedConf() throws Exception {
         runALDB(
             "load models/river_crossing.als",


### PR DESCRIPTION
`stateSigData` was not being overwritten when doing a `trace` after a `load`, and so bogus states were being loaded into `statePath`.

Closes #15.