### PR TITLE
Add ability to constrain steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ The `step [n | constraints]` command performs n state transitions from the curre
 
 Specify an integer value of n >= 1. By default, n = 1.
 
-A list of constraints may also be specified, as a comma-separated list enclosed by square brackets.
+Alternatively, step constraints can be specified, as a comma-separated list enclosed by square brackets.
 n is equal to the number of items in the list.
 The i-th constraint is applied when performing the i-th transition.
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The `step [n | constraints]` command performs n state transitions from the curre
 Specify an integer value of n >= 1. By default, n = 1.
 
 A list of constraints may also be specified, as a comma-separated list enclosed by square brackets.
-The number of items in the list is used to determine n.
+n is equal to the number of items in the list.
 The i-th constraint is applied when performing the i-th transition.
 
 ![image](https://user-images.githubusercontent.com/13455356/79278678-347df000-7e7a-11ea-90d7-111733a448a6.png)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ until | Run until constraints are met
 ### Detailed Descriptions
 
 #### alias
-The `alias [-c] [-l] [-rm] <alias> <predicate>` command allows for assigning a shorthand alias for a predicate. These aliases can be used when adding constraints via the `break` command.
+The `alias [-c] [-l] [-rm] <alias> <predicate>` command allows for assigning a shorthand alias for a predicate. These aliases can be used when adding constraints via the `break` command or specifying constraints in the `step` command.
 
 Specify the `-c` option to clear all aliases.
 Specify the `-l` option to list all current aliases.
@@ -176,9 +176,13 @@ additionalSigScopes: {}
 Running `setconf` with no filename will set the above default options.
 
 #### step
-The `step [n]` command performs n state transitions from the current execution state, ending at one of the valid states for a length (current + n) state traversal from the initial state.
+The `step [n | constraints]` command performs n state transitions from the current execution state, ending at one of the valid states for a length (current + n) state traversal from the initial state.
 
 Specify an integer value of n >= 1. By default, n = 1.
+
+A list of constraints may also be specified, as a comma-separated list enclosed by square brackets.
+The number of items in the list is used to determine n.
+The i-th constraint is applied when performing the i-th transition.
 
 ![image](https://user-images.githubusercontent.com/13455356/79278678-347df000-7e7a-11ea-90d7-111733a448a6.png)
 

--- a/src/alloy/AlloyConstants.java
+++ b/src/alloy/AlloyConstants.java
@@ -2,12 +2,16 @@ package alloy;
 
 public class AlloyConstants {
     public static final String ALLOY_ATOM_SEPARATOR = "\\$";
+    public static final String ALWAYS_TRUE = "none = none";
+    public static final String AND = "and";
     public static final String BLOCK_INITIALIZER = "{";
     public static final String BLOCK_TERMINATOR = "}";
     public static final String NONE = "none";
     public static final String TRACE_SOURCE_TAG = "source";
     public static final String TRACE_FILENAME_ATTR = "filename";
     public static final String TRACE_CONTENT_ATTR = "content";
+    public static final String PATH_AUXILIARY_PREDICATE_FORMAT = "path_c%d";
+    public static final String PATH_PREDICATE_NAME = "path";
     public static final String PLUS = "+";
     public static final String UNDERSCORE = "_";
     public static final String SET_DELIMITER = "->";

--- a/src/commands/CommandConstants.java
+++ b/src/commands/CommandConstants.java
@@ -93,7 +93,7 @@ public class CommandConstants {
         "Usage: step [n | constraints]\n\n" +
         "n must be an integer >= 1. By default, n = 1.\n\n" +
         "A list of constraints may also be specified, as a comma-separated list enclosed by square brackets.\n" +
-        "The number of items in the list is used to determine n.\n" +
+        "n is equal to the number of items in the list.\n" +
         "The i-th constraint is applied when performing the i-th transition.";
     public final static String[] STEP_SHORTHAND = {"s", "st"};
 

--- a/src/commands/CommandConstants.java
+++ b/src/commands/CommandConstants.java
@@ -90,8 +90,11 @@ public class CommandConstants {
     public final static String STEP_NAME = "step";
     public final static String STEP_DESCRIPTION = "Perform a state transition of n steps";
     public final static String STEP_HELP = "Perform a state transition of n steps.\n\n" +
-        "Usage: step [n]\n\n" +
-        "n must be an integer >= 1. By default, n = 1.";
+        "Usage: step [n | constraints]\n\n" +
+        "n must be an integer >= 1. By default, n = 1.\n\n" +
+        "A list of constraints may also be specified, as a comma-separated list enclosed by square brackets.\n" +
+        "The number of items in the list is used to determine n.\n" +
+        "The i-th constraint is applied when performing the i-th transition.";
     public final static String[] STEP_SHORTHAND = {"s", "st"};
 
     public final static String TRACE_NAME = "trace";

--- a/src/commands/CommandConstants.java
+++ b/src/commands/CommandConstants.java
@@ -92,7 +92,7 @@ public class CommandConstants {
     public final static String STEP_HELP = "Perform a state transition of n steps.\n\n" +
         "Usage: step [n | constraints]\n\n" +
         "n must be an integer >= 1. By default, n = 1.\n\n" +
-        "A list of constraints may also be specified, as a comma-separated list enclosed by square brackets.\n" +
+        "Alternatively, step constraints can be specified, as a comma-separated list enclosed by square brackets.\n" +
         "n is equal to the number of items in the list.\n" +
         "The i-th constraint is applied when performing the i-th transition.";
     public final static String[] STEP_SHORTHAND = {"s", "st"};

--- a/src/commands/StepCommand.java
+++ b/src/commands/StepCommand.java
@@ -76,7 +76,9 @@ public class StepCommand extends Command {
             return;
         }
 
-        simulationManager.performStep(steps, constraints);
+        if (!simulationManager.performStep(steps, constraints)) {
+            return;
+        }
 
         if (simulationManager.isTrace()) {
             System.out.println(simulationManager.getCurrentStateDiffString());

--- a/src/commands/StepCommand.java
+++ b/src/commands/StepCommand.java
@@ -1,6 +1,11 @@
 package commands;
 
+import simulation.AliasManager;
 import simulation.SimulationManager;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class StepCommand extends Command {
     private final static String[] SHORTHAND = CommandConstants.STEP_SHORTHAND;
@@ -28,12 +33,41 @@ public class StepCommand extends Command {
         }
 
         int steps = 1;
+        List<String> constraints = new ArrayList<String>();
+
         if (input.length > 1) {
-            try {
-                steps = Integer.parseInt(input[1]);
-            } catch (NumberFormatException e) {
-                System.out.println(CommandConstants.INTEGER_ERROR);
-                return;
+            String params = String.join(" ", Arrays.copyOfRange(input, 1, input.length)).trim();
+            // Check if a list of constraints is specified.
+            if (params.matches("\\[.*\\]")) {
+                params = params.substring(1, params.length() - 1);
+
+                AliasManager am = simulationManager.getAliasManager();
+                for (String constraint : params.split(",", -1)) {
+                    constraint = constraint.trim();
+                    if (constraint.matches("\".*\"")) {
+                        constraint = constraint.substring(1, constraint.length() - 1);
+                    }
+
+                    if (am.isAlias(constraint)) {
+                        constraint = am.getPredicate(constraint);
+                    }
+
+                    if (simulationManager.validateConstraint(constraint)) {
+                        constraints.add(constraint);
+                    } else {
+                        System.out.println(String.format(CommandConstants.INVALID_CONSTRAINT, constraint));
+                        return;
+                    }
+                }
+
+                steps = constraints.size();
+            } else {
+                try {
+                    steps = Integer.parseInt(input[1]);
+                } catch (NumberFormatException e) {
+                    System.out.println(CommandConstants.INTEGER_ERROR);
+                    return;
+                }
             }
         }
 
@@ -42,7 +76,7 @@ public class StepCommand extends Command {
             return;
         }
 
-        simulationManager.performStep(steps);
+        simulationManager.performStep(steps, constraints);
 
         if (simulationManager.isTrace()) {
             System.out.println(simulationManager.getCurrentStateDiffString());

--- a/src/simulation/SimulationManager.java
+++ b/src/simulation/SimulationManager.java
@@ -243,9 +243,10 @@ public class SimulationManager {
     /**
      * performStep steps the transition system forward by `steps` state transitions.
      * @param steps
+     * @return boolean
      */
-    public void performStep(int steps) {
-        performStep(steps, new ArrayList<String>());
+    public boolean performStep(int steps) {
+        return performStep(steps, new ArrayList<String>());
     }
 
     /**
@@ -253,11 +254,12 @@ public class SimulationManager {
      * The i-th constraint in `constraints` is applied to the i-th transition.
      * @param steps
      * @param constraints
+     * @return boolean
      */
-    public void performStep(int steps, List<String> constraints) {
+    public boolean performStep(int steps, List<String> constraints) {
         if (isTrace()) {
             statePath.incrementPosition(steps);
-            return;
+            return true;
         }
 
         statePath.commitNodes();
@@ -276,19 +278,19 @@ public class SimulationManager {
             );
         } catch (IOException e) {
             System.out.println("Cannot perform step. I/O failed.");
-            return;
+            return false;
         }
 
         CompModule compModule = AlloyInterface.compile(alloyModelFile.getAbsolutePath());
         if (compModule == null) {
             System.out.println("Cannot perform step. Could not parse model.");
-            return;
+            return false;
         }
 
         A4Solution sol = AlloyInterface.run(compModule);
         if (sol == null || !sol.satisfiable()) {
             System.out.println("Cannot perform step. Transition constraint is unsatisfiable.");
-            return;
+            return false;
         }
 
         StateNode startNode = statePath.getCurNode();
@@ -305,6 +307,8 @@ public class SimulationManager {
 
         this.activeSolutions.clear();
         this.activeSolutions.push(sol);
+
+        return true;
     }
 
     public boolean selectAlternatePath(boolean reverse) {

--- a/test/commands/TestStepCommand.java
+++ b/test/commands/TestStepCommand.java
@@ -43,7 +43,7 @@ public class TestStepCommand extends TestCommand {
         setupStreams();
         String state = "state";
         when(simulationManager.isInitialized()).thenReturn(true);
-        doNothing().when(simulationManager).performStep(isA(Integer.class), isA(List.class));
+        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
         when(simulationManager.getCurrentStateString()).thenReturn(state);
 
         String[] input = {"s", "3"};
@@ -59,7 +59,7 @@ public class TestStepCommand extends TestCommand {
         setupStreams();
         String state = "state";
 
-        doNothing().when(simulationManager).performStep(isA(Integer.class), isA(List.class));
+        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.getAliasManager()).thenReturn(am);
         when(simulationManager.getCurrentStateString()).thenReturn(state);
@@ -83,7 +83,7 @@ public class TestStepCommand extends TestCommand {
         setupStreams();
         String state = "state";
 
-        doNothing().when(simulationManager).performStep(isA(Integer.class), isA(List.class));
+        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.getAliasManager()).thenReturn(am);
         when(simulationManager.getCurrentStateString()).thenReturn(state);
@@ -107,7 +107,7 @@ public class TestStepCommand extends TestCommand {
         setupStreams();
         String state = "state";
 
-        doNothing().when(simulationManager).performStep(isA(Integer.class), isA(List.class));
+        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.getAliasManager()).thenReturn(am);
         when(simulationManager.getCurrentStateString()).thenReturn(state);
@@ -131,7 +131,7 @@ public class TestStepCommand extends TestCommand {
         setupStreams();
         String state = "state";
 
-        doNothing().when(simulationManager).performStep(isA(Integer.class), isA(List.class));
+        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.getAliasManager()).thenReturn(am);
         when(simulationManager.getCurrentStateString()).thenReturn(state);
@@ -158,7 +158,7 @@ public class TestStepCommand extends TestCommand {
         setupStreams();
         String state = "state";
 
-        doNothing().when(simulationManager).performStep(isA(Integer.class), isA(List.class));
+        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.getAliasManager()).thenReturn(am);
         when(simulationManager.getCurrentStateString()).thenReturn(state);
@@ -178,7 +178,7 @@ public class TestStepCommand extends TestCommand {
         String trace = "trace";
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.isTrace()).thenReturn(true);
-        doNothing().when(simulationManager).performStep(isA(Integer.class), isA(List.class));
+        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
         when(simulationManager.getCurrentStateDiffString()).thenReturn(trace);
 
         String[] input = {"s", "3"};

--- a/test/simulation/TestSimulationManager.java
+++ b/test/simulation/TestSimulationManager.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -243,6 +244,84 @@ public class TestSimulationManager {
         assertEquals(expectedDOTString, sm.getDOTString());
         assertEquals(expectedCurrentState, sm.getCurrentStateString());
         assertEquals(expectedHistory, sm.getHistory(1));
+    }
+
+    @Test
+    public void testPerformStep_withConstraintsSatisfiable() throws IOException {
+        initializeTestWithModelPath("models/river_crossing.als");
+        String expectedDOTString = String.join("\n",
+            "digraph graphname {",
+            "\tS1 -> S2",
+            "\tS2 -> S3",
+            "\tS3",
+            "}",
+            ""
+        );
+        String expectedCurrentState = String.join("\n",
+            "",
+            "S3",
+            "----",
+            "far: { Chicken }",
+            "near: { Farmer, Fox, Grain }",
+            ""
+        );
+        String expectedHistory = String.join("\n",
+            "",
+            "(-2)",
+            "----",
+            "S1",
+            "----",
+            "far: {  }",
+            "near: { Chicken, Farmer, Fox, Grain }",
+            "",
+            "(-1)",
+            "----",
+            "S2",
+            "----",
+            "far: { Chicken, Farmer }",
+            "near: { Fox, Grain }",
+            ""
+        );
+
+        List<String> constraints = new ArrayList<String>(
+            Arrays.asList("Chicken in far", "(Farmer in near) and (Chicken in far)")
+        );
+        sm.initializeWithModel(modelFile);
+        sm.performStep(constraints.size(), constraints);
+        assertEquals(expectedDOTString, sm.getDOTString());
+        assertEquals(expectedCurrentState, sm.getCurrentStateString());
+        assertEquals(expectedHistory, sm.getHistory(2));
+    }
+
+    @Test
+    public void testPerformStep_withConstraintsUnsatisfiable() throws IOException {
+        initializeTestWithModelPath("models/river_crossing.als");
+        String expectedDOTString = String.join("\n",
+            "digraph graphname {",
+            "\tS1",
+            "}",
+            ""
+        );
+        String expectedCurrentState = String.join("\n",
+            "",
+            "S1",
+            "----",
+            "far: {  }",
+            "near: { Chicken, Farmer, Fox, Grain }",
+            ""
+        );
+        String expectedHistory = String.join("\n",
+            ""
+        );
+
+        List<String> constraints = new ArrayList<String>(
+            Arrays.asList("(Farmer in near) and (Farmer in far)")
+        );
+        sm.initializeWithModel(modelFile);
+        sm.performStep(constraints.size(), constraints);
+        assertEquals(expectedDOTString, sm.getDOTString());
+        assertEquals(expectedCurrentState, sm.getCurrentStateString());
+        assertEquals(expectedHistory, sm.getHistory(2));
     }
 
     @Test


### PR DESCRIPTION
A list of constraints can now be specified alongside the `step` command, enabling the user to specify paths of execution. The length of the list represents the number of transitions, and the i-th element of the list is the constraint applied to the i-th transition.

If an empty string is specified as a constraint at a particular index, no constraint will be applied to the corresponding transition.

This functionality is implemented by creating an auxiliary predicate for each constraint. After these predicates have been created, a master `path` predicate is generated, containing a conjunction of the auxiliary predicates. Finally, the run command calls `path[first]` to apply the master predicate beginning at the first state.

Usage example:
```
(aldb) load models/river_crossing.als
Reading model from models/river_crossing.als...done.
(aldb) step ["Chicken in far"]

S2
----
far: { Chicken, Farmer }
near: { Fox, Grain }

(aldb) step ["", "far=Chicken+Farmer+Grain"]

S4
----
far: { Chicken, Farmer, Grain }
near: { Fox }

(aldb) history

(-3)
----
S1
----
far: {  }
near: { Chicken, Farmer, Fox, Grain }

(-2)
----
S2
----
far: { Chicken, Farmer }
near: { Fox, Grain }

(-1)
----
S3
----
far: { Chicken }
near: { Farmer, Fox, Grain }
```

Closes #17.