### PR TITLE
Do not create concrete sigs for bitwidth-scoped signatures

### DIFF
--- a/models/even_odd.als
+++ b/models/even_odd.als
@@ -3,6 +3,7 @@
  *  # Additional Alloy sig scopes to specify.
  *  additionalSigScopes:
  *    Int: 6
+ *    seq: 6
  *
  *  END_ALDB_CONF
  */

--- a/src/alloy/AlloyConstants.java
+++ b/src/alloy/AlloyConstants.java
@@ -1,5 +1,10 @@
 package alloy;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Collections;
+
 public class AlloyConstants {
     public static final String ALLOY_ATOM_SEPARATOR = "\\$";
     public static final String ALWAYS_TRUE = "none = none";
@@ -16,10 +21,14 @@ public class AlloyConstants {
     public static final String PLUS = "+";
     public static final String UNDERSCORE = "_";
     public static final String SET_DELIMITER = "->";
+    public static final String SEQ = "seq";
     public static final String VALUE_SUFFIX = "$0";
     public static final String THIS = "this/";
     public static final String UNIV = "univ";
     public static final String CONCRETE_SIG_REGEX = "(.*)_(\\d+)";
     public static final String OR = "or";
     public static final String BREAK_PREDICATE_NAME = "break";
+
+    public static final Set<String> BITWIDTH_SCOPED_SIGS =
+        Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(INT, SEQ)));
 }

--- a/src/alloy/AlloyUtils.java
+++ b/src/alloy/AlloyUtils.java
@@ -53,9 +53,7 @@ public class AlloyUtils {
             }
 
             String sigName = entry.getKey();
-            // The scope of Int specifies bitwidth and does not require the
-            // creation of concrete signatures.
-            if (sigName.equals(AlloyConstants.INT)) {
+            if (AlloyConstants.BITWIDTH_SCOPED_SIGS.contains(sigName)) {
                 continue;
             }
 
@@ -224,8 +222,7 @@ public class AlloyUtils {
         );
         String sigScopes = String.format("run { %s } for exactly %d %s", runConstraint, steps + 1, stateSigName);
         for (String sigScopeName : additionalSigScopes.keySet()) {
-            // Alloy does not accept "exactly" for Int scope.
-            String scopeFormat = (sigScopeName.equals(AlloyConstants.INT)) ?
+            String scopeFormat = (AlloyConstants.BITWIDTH_SCOPED_SIGS.contains(sigScopeName)) ?
                                      ", %d %s" :
                                      ", exactly %d %s";
             sigScopes += String.format(scopeFormat, additionalSigScopes.get(sigScopeName), sigScopeName);

--- a/test/alloy/TestAlloyUtils.java
+++ b/test/alloy/TestAlloyUtils.java
@@ -67,6 +67,7 @@ public class TestAlloyUtils {
         sigScopes.put("Player", 4);
         sigScopes.put("Chair", 3);
         sigScopes.put("Int", 6);
+        sigScopes.put("seq", 6);
 
         ParsingConf pc = new ParsingConf();
         pc.setStateSigName("Snapshot");
@@ -83,7 +84,7 @@ public class TestAlloyUtils {
             "",
             "fact { all s: Snapshot, s': s.next { trans[s, s'] } }",
             "",
-            "run {  } for exactly 6 Snapshot, exactly 3 Chair, 6 Int, exactly 4 Player"
+            "run {  } for exactly 6 Snapshot, exactly 3 Chair, 6 Int, exactly 4 Player, 6 seq"
         );
         String result = AlloyUtils.annotatedTransitionSystem(
                             model,
@@ -234,6 +235,7 @@ public class TestAlloyUtils {
         sigScopes.put("Player", 4);
         sigScopes.put("Chair", 3);
         sigScopes.put("Int", 6);
+        sigScopes.put("seq", 6);
 
         String expected = String.join("\n",
             "one sig Chair_0, Chair_1, Chair_2 extends Chair {}",

--- a/test/simulation/TestSimulationManager.java
+++ b/test/simulation/TestSimulationManager.java
@@ -221,7 +221,7 @@ public class TestSimulationManager {
     }
 
     @Test
-    public void testPerformStep_modelWithIntScope() throws IOException {
+    public void testPerformStep_modelWithBitwidthScope() throws IOException {
         initializeTestWithModelPath("models/even_odd.als");
         String expectedDOTString = String.join("\n",
             "digraph graphname {",


### PR DESCRIPTION
#27 addressed the issue for `Int`, but it did not account for `seq`. This change ensures that all signatures that are bidwidth-scoped can be used in aldb.

According to the Alloy [parser](https://github.com/beckus/AlloyAnalyzer/blob/master/edu/mit/csail/sdg/alloy4compiler/parser/Alloy.cup#L628), `Int` and `seq` are the only two signatures that have this property.

Closes #33.