### PR TITLE
Move special constraints from run command to facts

### DIFF
--- a/src/alloy/AlloyUtils.java
+++ b/src/alloy/AlloyUtils.java
@@ -212,15 +212,16 @@ public class AlloyUtils {
      * 3. Add fact to define state transitions.
      * 4. Add command to run state transitions.
      */
-    private static String annotatedTransitionSystem(String model, ParsingConf parsingConf, int steps, String runConstraint) {
+    private static String annotatedTransitionSystem(String model, ParsingConf parsingConf, int steps, String additionalConstraint) {
         String stateSigName = parsingConf.getStateSigName();
         String initPredicateName = parsingConf.getInitPredicateName();
         String transitionRelationName = parsingConf.getTransitionRelationName();
         Map<String, Integer> additionalSigScopes = parsingConf.getAdditionalSigScopes();
+        String additionalConstraintFact = additionalConstraint.trim().isEmpty() ? "" : String.format("fact { %s }" + "\n\n", additionalConstraint);
         String transitionRelationFact = String.format(
             "fact { all s: %s, s': s.next { %s[s, s'] } }" + "\n\n", stateSigName, transitionRelationName
         );
-        String sigScopes = String.format("run { %s } for exactly %d %s", runConstraint, steps + 1, stateSigName);
+        String sigScopes = String.format("run {  } for exactly %d %s", steps + 1, stateSigName);
         for (String sigScopeName : additionalSigScopes.keySet()) {
             String scopeFormat = (AlloyConstants.BITWIDTH_SCOPED_SIGS.contains(sigScopeName)) ?
                                      ", %d %s" :
@@ -231,6 +232,7 @@ public class AlloyUtils {
             String.format("open util/ordering[%s]" + "\n\n", stateSigName) +
             model + "\n\n" +
             String.format("fact { %s[first] }" + "\n\n", initPredicateName) +
+            additionalConstraintFact +
             transitionRelationFact +
             sigScopes,
             model

--- a/test/alloy/TestAlloyUtils.java
+++ b/test/alloy/TestAlloyUtils.java
@@ -106,9 +106,11 @@ public class TestAlloyUtils {
             "",
             "fact { init[first] }",
             "",
+            "fact { path[first] }",
+            "",
             "fact { all s: State, s': s.next { next[s, s'] } }",
             "",
-            "run { path[first] } for exactly 6 State"
+            "run {  } for exactly 6 State"
         );
         String result = AlloyUtils.annotatedTransitionSystemStep(
                             model,
@@ -130,9 +132,11 @@ public class TestAlloyUtils {
             "",
             "fact { init[first] }",
             "",
+            "fact { break[last] }",
+            "",
             "fact { all s: State, s': s.next { next[s, s'] } }",
             "",
-            "run { break[last] } for exactly 6 State"
+            "run {  } for exactly 6 State"
         );
         String result = AlloyUtils.annotatedTransitionSystemUntil(
                             model,


### PR DESCRIPTION
Closes #37. 

It is cleaner to uniformly use an empty `run { }` command for every function, and specify any additional constraints within facts.