### PR TITLE
Display differential state output when stepping

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Running `setconf` with no filename will set the above default options.
 
 #### step
 The `step [n | constraints]` command performs n state transitions from the current execution state, ending at one of the valid states for a length (current + n) state traversal from the initial state.
+The **differential output** between the previous and new state is displayed. To see the full state output, use the [`current`](#current) command.
 
 Specify an integer value of n >= 1. By default, n = 1.
 

--- a/src/commands/CommandConstants.java
+++ b/src/commands/CommandConstants.java
@@ -94,7 +94,7 @@ public class CommandConstants {
 
     public final static String STEP_NAME = "step";
     public final static String STEP_DESCRIPTION = "Perform a state transition of n steps";
-    public final static String STEP_HELP = "Perform a state transition of n steps.\n\n" +
+    public final static String STEP_HELP = "Perform a state transition of n steps. The differential output between the previous and new state is displayed.\n\n" +
         "Usage: step [n | constraints]\n\n" +
         "n must be an integer >= 1. By default, n = 1.\n\n" +
         "Alternatively, step constraints can be specified, as a comma-separated list enclosed by square brackets.\n" +

--- a/src/commands/StepCommand.java
+++ b/src/commands/StepCommand.java
@@ -76,15 +76,8 @@ public class StepCommand extends Command {
             return;
         }
 
-        if (!simulationManager.performStep(steps, constraints)) {
-            return;
+        if (simulationManager.performStep(steps, constraints)) {
+            System.out.println(simulationManager.getCurrentStateDiffString(steps));
         }
-
-        if (simulationManager.isTrace()) {
-            System.out.println(simulationManager.getCurrentStateDiffString());
-            return;
-        }
-
-        System.out.println(simulationManager.getCurrentStateString());
     }
 }

--- a/src/simulation/SimulationManager.java
+++ b/src/simulation/SimulationManager.java
@@ -512,8 +512,8 @@ public class SimulationManager {
         return statePath.getCurNode().stringForProperty(property);
     }
 
-    public String getCurrentStateDiffString() {
-        return statePath.getCurNode().getDiffString(statePath.getPrevNode());
+    public String getCurrentStateDiffString(int steps) {
+        return statePath.getCurNode().getDiffString(statePath.getNode(statePath.getPosition() - steps));
     }
 
     public AliasManager getAliasManager() {

--- a/src/state/StatePath.java
+++ b/src/state/StatePath.java
@@ -9,7 +9,6 @@ import java.util.List;
 public class StatePath {
     private List<StateNode> path;
     int tempPathSize;
-    private StateNode prev;
     private int position;
 
     public StatePath() {
@@ -47,12 +46,7 @@ public class StatePath {
         return path.isEmpty() ? null : path.get(position);
     }
 
-    public StateNode getPrevNode() {
-        return prev;
-    }
-
     public void setPosition(int position) {
-        prev = getCurNode();
         this.position = position;
     }
 
@@ -67,15 +61,9 @@ public class StatePath {
     public void decrementPosition(int steps, boolean traceMode) {
         int newPos = position < steps ? 0 : position - steps;
         setPosition(newPos);
-        if (position == 0) {
-            prev = null;
-        } else {
-            prev = path.get(position - 1);
+        if (!traceMode) {
+            path = path.subList(0, newPos + 1);
         }
-        if (traceMode) {
-            return;
-        }
-        path = path.subList(0, newPos + 1);
     }
 
     public void commitNodes() {

--- a/test/commands/TestStepCommand.java
+++ b/test/commands/TestStepCommand.java
@@ -42,14 +42,16 @@ public class TestStepCommand extends TestCommand {
     public void testExecute_integer() {
         setupStreams();
         String state = "state";
+        int expectedSteps = 3;
+
         when(simulationManager.isInitialized()).thenReturn(true);
-        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
-        when(simulationManager.getCurrentStateString()).thenReturn(state);
+        when(simulationManager.performStep(eq(expectedSteps), anyList())).thenReturn(true);
+        when(simulationManager.getCurrentStateDiffString(expectedSteps)).thenReturn(state);
 
         String[] input = {"s", "3"};
         step.execute(input, simulationManager);
-        verify(simulationManager).performStep(3, new ArrayList<String>());
-        verify(simulationManager).getCurrentStateString();
+        verify(simulationManager).performStep(expectedSteps, new ArrayList<String>());
+        verify(simulationManager).getCurrentStateDiffString(expectedSteps);
         assertEquals(state + "\n", outContent.toString());
         restoreStreams();
     }
@@ -58,22 +60,22 @@ public class TestStepCommand extends TestCommand {
     public void testExecute_constraints() {
         setupStreams();
         String state = "state";
+        int expectedSteps = 4;
 
-        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
+        when(simulationManager.performStep(eq(expectedSteps), anyList())).thenReturn(true);
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.getAliasManager()).thenReturn(am);
-        when(simulationManager.getCurrentStateString()).thenReturn(state);
+        when(simulationManager.getCurrentStateDiffString(expectedSteps)).thenReturn(state);
         when(simulationManager.validateConstraint(anyString())).thenReturn(true);
 
         String rawInput = "s [a, \"b and c\", d, \"e\"]";
-        int expectedSteps = 4;
         List<String> expectedConstraints = new ArrayList<String>(
             Arrays.asList("a", "b and c", "d", "e")
         );
 
         step.execute(rawInput.split(" "), simulationManager);
         verify(simulationManager).performStep(expectedSteps, expectedConstraints);
-        verify(simulationManager).getCurrentStateString();
+        verify(simulationManager).getCurrentStateDiffString(expectedSteps);
         assertEquals(state + "\n", outContent.toString());
         restoreStreams();
     }
@@ -82,22 +84,22 @@ public class TestStepCommand extends TestCommand {
     public void testExecute_constraintsEmpty() {
         setupStreams();
         String state = "state";
+        int expectedSteps = 1;
 
-        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
+        when(simulationManager.performStep(eq(expectedSteps), anyList())).thenReturn(true);
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.getAliasManager()).thenReturn(am);
-        when(simulationManager.getCurrentStateString()).thenReturn(state);
+        when(simulationManager.getCurrentStateDiffString(expectedSteps)).thenReturn(state);
         when(simulationManager.validateConstraint(anyString())).thenReturn(true);
 
         String rawInput = "s []";
-        int expectedSteps = 1;
         List<String> expectedConstraints = new ArrayList<String>(
             Arrays.asList("")
         );
 
         step.execute(rawInput.split(" "), simulationManager);
         verify(simulationManager).performStep(expectedSteps, expectedConstraints);
-        verify(simulationManager).getCurrentStateString();
+        verify(simulationManager).getCurrentStateDiffString(expectedSteps);
         assertEquals(state + "\n", outContent.toString());
         restoreStreams();
     }
@@ -106,22 +108,22 @@ public class TestStepCommand extends TestCommand {
     public void testExecute_constraintsBlank() {
         setupStreams();
         String state = "state";
+        int expectedSteps = 5;
 
-        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
+        when(simulationManager.performStep(eq(expectedSteps), anyList())).thenReturn(true);
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.getAliasManager()).thenReturn(am);
-        when(simulationManager.getCurrentStateString()).thenReturn(state);
+        when(simulationManager.getCurrentStateDiffString(expectedSteps)).thenReturn(state);
         when(simulationManager.validateConstraint(anyString())).thenReturn(true);
 
         String rawInput = "s [\"\", ,, \"\",]";
-        int expectedSteps = 5;
         List<String> expectedConstraints = new ArrayList<String>(
             Arrays.asList("", "", "", "", "")
         );
 
         step.execute(rawInput.split(" "), simulationManager);
         verify(simulationManager).performStep(expectedSteps, expectedConstraints);
-        verify(simulationManager).getCurrentStateString();
+        verify(simulationManager).getCurrentStateDiffString(expectedSteps);
         assertEquals(state + "\n", outContent.toString());
         restoreStreams();
     }
@@ -130,25 +132,25 @@ public class TestStepCommand extends TestCommand {
     public void testExecute_constraintsAlias() {
         setupStreams();
         String state = "state";
+        int expectedSteps = 1;
 
-        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
+        when(simulationManager.performStep(eq(expectedSteps), anyList())).thenReturn(true);
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.getAliasManager()).thenReturn(am);
-        when(simulationManager.getCurrentStateString()).thenReturn(state);
+        when(simulationManager.getCurrentStateDiffString(expectedSteps)).thenReturn(state);
         when(simulationManager.validateConstraint(anyString())).thenReturn(true);
 
         when(am.isAlias(anyString())).thenReturn(true);
         when(am.getFormula(anyString())).thenReturn("a");
 
         String rawInput = "s [f1]";
-        int expectedSteps = 1;
         List<String> expectedConstraints = new ArrayList<String>(
             Arrays.asList("a")
         );
 
         step.execute(rawInput.split(" "), simulationManager);
         verify(simulationManager).performStep(expectedSteps, expectedConstraints);
-        verify(simulationManager).getCurrentStateString();
+        verify(simulationManager).getCurrentStateDiffString(expectedSteps);
         assertEquals(state + "\n", outContent.toString());
         restoreStreams();
     }
@@ -161,31 +163,15 @@ public class TestStepCommand extends TestCommand {
         when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.getAliasManager()).thenReturn(am);
-        when(simulationManager.getCurrentStateString()).thenReturn(state);
+        when(simulationManager.getCurrentStateDiffString(anyInt())).thenReturn(state);
         when(simulationManager.validateConstraint(anyString())).thenReturn(false);
 
         String rawInput = "s [a]";
         String expectedOutput = String.format(CommandConstants.INVALID_CONSTRAINT, "a") + "\n";
 
         step.execute(rawInput.split(" "), simulationManager);
+        verify(simulationManager, never()).getCurrentStateDiffString(anyInt());
         assertEquals(expectedOutput, outContent.toString());
-        restoreStreams();
-    }
-
-    @Test
-    public void testExecute_isTrace() {
-        setupStreams();
-        String trace = "trace";
-        when(simulationManager.isInitialized()).thenReturn(true);
-        when(simulationManager.isTrace()).thenReturn(true);
-        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
-        when(simulationManager.getCurrentStateDiffString()).thenReturn(trace);
-
-        String[] input = {"s", "3"};
-        step.execute(input, simulationManager);
-        verify(simulationManager).performStep(3, new ArrayList<String>());
-        verify(simulationManager).getCurrentStateDiffString();
-        assertEquals(trace + "\n", outContent.toString());
         restoreStreams();
     }
 

--- a/test/state/TestStatePath.java
+++ b/test/state/TestStatePath.java
@@ -91,21 +91,6 @@ public class TestStatePath {
     }
 
     @Test
-    public void testGetPrevNode() {
-        StatePath sp = new StatePath();
-        assertEquals(null, sp.getPrevNode());
-
-        List<StateNode> path = new ArrayList<StateNode>();
-        path.add(n0);
-        path.add(n1);
-        sp.initWithPath(path);
-        assertEquals(null, sp.getPrevNode());
-
-        sp.setPosition(0);
-        assertEquals(n1, sp.getPrevNode());
-    }
-
-    @Test
     public void testSetAndGetPosition() {
         StatePath sp = new StatePath();
         assertEquals(0, sp.getPosition());
@@ -117,7 +102,6 @@ public class TestStatePath {
         assertEquals(1, sp.getPosition());
 
         sp.setPosition(0);
-        assertEquals(n1, sp.getPrevNode());
         assertEquals(0, sp.getPosition());
     }
 
@@ -136,12 +120,10 @@ public class TestStatePath {
 
         sp.incrementPosition(1);
         assertEquals(1, sp.getPosition());
-        assertEquals(n0, sp.getPrevNode());
         assertFalse(sp.atEnd());
 
         sp.incrementPosition(1);
         assertEquals(2, sp.getPosition());
-        assertEquals(n1, sp.getPrevNode());
         assertTrue(sp.atEnd());
     }
 
@@ -157,7 +139,6 @@ public class TestStatePath {
 
         sp.decrementPosition(1, false);
         assertEquals(1, sp.getPosition());
-        assertEquals(n0, sp.getPrevNode());
         assertEquals(n1, sp.getCurNode());
 
         // Decrement path size 3 by 2.
@@ -166,7 +147,6 @@ public class TestStatePath {
 
         sp.decrementPosition(2, false);
         assertEquals(0, sp.getPosition());
-        assertEquals(null, sp.getPrevNode());
         assertEquals(n0, sp.getCurNode());
 
         // Decrement path size 3 by 3.
@@ -175,7 +155,6 @@ public class TestStatePath {
 
         sp.decrementPosition(3, false);
         assertEquals(0, sp.getPosition());
-        assertEquals(null, sp.getPrevNode());
         assertEquals(n0, sp.getCurNode());
 
         // Decrement path size 3 by 4.
@@ -184,7 +163,6 @@ public class TestStatePath {
 
         sp.decrementPosition(4, false);
         assertEquals(0, sp.getPosition());
-        assertEquals(null, sp.getPrevNode());
         assertEquals(n0, sp.getCurNode());
     }
 
@@ -196,7 +174,6 @@ public class TestStatePath {
         tempPath.add(n1);
         sp.setTempPath(tempPath);
         assertEquals(1, sp.getPosition());
-        assertEquals(null, sp.getPrevNode());
         assertEquals(n1, sp.getCurNode());
     }
 
@@ -211,7 +188,6 @@ public class TestStatePath {
 
         sp.clearTempPath();
         assertEquals(-1, sp.getPosition());
-        assertEquals(null, sp.getPrevNode());
         assertEquals(null, sp.getCurNode());
 
         // Clear temp path with an initial path set.
@@ -220,13 +196,11 @@ public class TestStatePath {
         // Should be a no-op.
         sp.clearTempPath();
         assertEquals(1, sp.getPosition());
-        assertEquals(null, sp.getPrevNode());
         assertEquals(n1, sp.getCurNode());
 
         sp.setTempPath(tempPath);
         sp.clearTempPath();
         assertEquals(1, sp.getPosition());
-        assertEquals(null, sp.getPrevNode());
         assertEquals(n1, sp.getCurNode());
     }
 


### PR DESCRIPTION
This is done to maintain parity with the behaviour seen when stepping through traces. Full state output can still be displayed via the `current` command.

Closes #39.