### PR TITLE
Add differential output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ The `set <option> <value>` command allows users to modify ALDB options.
 
     This command sets the custom parsing configuration for the current session. For more information, see [Model and Configuration Format](#model-and-configuration-format).
 
+2) `set diff <on | off>`
+
+    This command turns on/off differential output for [`step`](#step) and [`alt`](#alt). When enabled, only fields that have changed between the previous and current state are displayed. By default, this option is disabled.
+
 #### step
 The `step [n | constraints]` command performs n state transitions from the current execution state, ending at one of the valid states for a length (current + n) state traversal from the initial state.
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The `set <option> <value>` command allows users to modify ALDB options.
 
 2) `set diff <on | off>`
 
-    This command turns on/off differential output for [`step`](#step) and [`alt`](#alt). When enabled, only fields that have changed between the previous and current state are displayed. By default, this option is disabled.
+    This command turns on/off differential output for [`step`](#step) and [`alt`](#alt). When enabled, only fields that have changed between the previous and current state are displayed. By default, this option is enabled.
 
 #### step
 The `step [n | constraints]` command performs n state transitions from the current execution state, ending at one of the valid states for a length (current + n) state traversal from the initial state.

--- a/src/commands/AltCommand.java
+++ b/src/commands/AltCommand.java
@@ -43,7 +43,7 @@ public class AltCommand extends Command {
         }
 
         if (simulationManager.isDiffMode()) {
-            System.out.println(simulationManager.getCurrentStateDiffString());
+            System.out.println(simulationManager.getCurrentStateDiffStringFromLastCommit());
         } else {
             System.out.println(simulationManager.getCurrentStateString());
         }

--- a/src/commands/AltCommand.java
+++ b/src/commands/AltCommand.java
@@ -43,7 +43,7 @@ public class AltCommand extends Command {
         }
 
         if (simulationManager.isDiffMode()) {
-            System.out.println(simulationManager.getCurrentStateDiffString(1));
+            System.out.println(simulationManager.getCurrentStateDiffString());
         } else {
             System.out.println(simulationManager.getCurrentStateString());
         }

--- a/src/commands/AltCommand.java
+++ b/src/commands/AltCommand.java
@@ -42,6 +42,10 @@ public class AltCommand extends Command {
             return;
         }
 
-        System.out.println(simulationManager.getCurrentStateString());
+        if (simulationManager.isDiffMode()) {
+            System.out.println(simulationManager.getCurrentStateDiffString(1));
+        } else {
+            System.out.println(simulationManager.getCurrentStateString());
+        }
     }
 }

--- a/src/commands/CommandConstants.java
+++ b/src/commands/CommandConstants.java
@@ -96,7 +96,7 @@ public class CommandConstants {
         "set diff <on | off>\n\n" +
         "    Turn on/off differential output mode.\n\n" +
         "    When enabled, only fields that have changed between the previous and current state are displayed when executing step or alt.\n" +
-        "    By default, this option is disabled.";
+        "    By default, this option is enabled.";
 
     public final static String STEP_NAME = "step";
     public final static String STEP_DESCRIPTION = "Perform a state transition of n steps";

--- a/src/commands/CommandConstants.java
+++ b/src/commands/CommandConstants.java
@@ -92,7 +92,11 @@ public class CommandConstants {
         "    transitionRelationName: next\n" +
         "    # Additional Alloy sig scopes to specify.\n" +
         "    additionalSigScopes: {}\n\n" +
-        "    Running set conf with no filename will set the above default options.";
+        "    Running set conf with no filename will set the above default options.\n\n" +
+        "set diff <on | off>\n\n" +
+        "    Turn on/off differential output mode.\n\n" +
+        "    When enabled, only fields that have changed between the previous and current state are displayed when executing step or alt.\n" +
+        "    By default, this option is disabled.";
 
     public final static String STEP_NAME = "step";
     public final static String STEP_DESCRIPTION = "Perform a state transition of n steps";

--- a/src/commands/SetCommand.java
+++ b/src/commands/SetCommand.java
@@ -12,6 +12,10 @@ import org.yaml.snakeyaml.error.YAMLException;
 
 public class SetCommand extends Command {
     private final static String CONF_OPTION = "conf";
+    private final static String DIFF_OPTION = "diff";
+
+    private final static String ON = "on";
+    private final static String OFF = "off";
 
     public String getName() {
         return CommandConstants.SET_NAME;
@@ -36,6 +40,9 @@ public class SetCommand extends Command {
         switch (option) {
             case CONF_OPTION:
                 setConf(input, simulationManager);
+                break;
+            case DIFF_OPTION:
+                setDiffMode(input, simulationManager);
                 break;
             default:
                 System.out.println(getHelp());
@@ -71,5 +78,21 @@ public class SetCommand extends Command {
             return;
         }
         System.out.println(CommandConstants.DONE);
+    }
+
+    private void setDiffMode(String[] input, SimulationManager simulationManager) {
+        if (input.length < 3) {
+            System.out.println(getHelp());
+            return;
+        }
+
+        String value = input[2];
+        if (value.equals(ON)) {
+            simulationManager.setDiffMode(true);
+        } else if (value.equals(OFF)) {
+            simulationManager.setDiffMode(false);
+        } else {
+            System.out.println(getHelp());
+        }
     }
 }

--- a/src/commands/StepCommand.java
+++ b/src/commands/StepCommand.java
@@ -81,7 +81,7 @@ public class StepCommand extends Command {
         }
 
         if (simulationManager.isDiffMode()) {
-            System.out.println(simulationManager.getCurrentStateDiffString(steps));
+            System.out.println(simulationManager.getCurrentStateDiffStringByDelta(steps));
         } else {
             System.out.println(simulationManager.getCurrentStateString());
 

--- a/src/commands/StepCommand.java
+++ b/src/commands/StepCommand.java
@@ -81,6 +81,7 @@ public class StepCommand extends Command {
         }
 
         if (simulationManager.isDiffMode()) {
+            // States are not generated and committed when stepping through traces, so get the diff by delta.
             System.out.println(simulationManager.getCurrentStateDiffStringByDelta(steps));
         } else {
             System.out.println(simulationManager.getCurrentStateString());

--- a/src/commands/StepCommand.java
+++ b/src/commands/StepCommand.java
@@ -80,11 +80,11 @@ public class StepCommand extends Command {
             return;
         }
 
-        if (simulationManager.isTrace()) {
-            System.out.println(simulationManager.getCurrentStateDiffString());
-            return;
-        }
+        if (simulationManager.isDiffMode()) {
+            System.out.println(simulationManager.getCurrentStateDiffString(steps));
+        } else {
+            System.out.println(simulationManager.getCurrentStateString());
 
-        System.out.println(simulationManager.getCurrentStateString());
+        }
     }
 }

--- a/src/simulation/SimulationManager.java
+++ b/src/simulation/SimulationManager.java
@@ -396,21 +396,22 @@ public class SimulationManager {
     }
 
     /**
-     * getCurrentStateDiffString returns the diff between the current and the previous last-committed state.
+     * getCurrentStateDiffStringFromLastCommit returns the diff between the current
+     * and the previous last-committed state.
      * @return String
      */
-    public String getCurrentStateDiffString() {
+    public String getCurrentStateDiffStringFromLastCommit() {
         StateNode prev = statePath.getNode(statePath.getPosition() - statePath.getTempPathSize());
         return statePath.getCurNode().getDiffString(prev);
     }
 
     /**
-     * getCurrentStateDiffString returns the diff between the current state and the state at the
-     * (current - delta) position in the path.
+     * getCurrentStateDiffStringByDelta returns the diff between the current state
+     * and the state at the (current - delta) position in the path.
      * @param int delta
      * @return String
      */
-    public String getCurrentStateDiffString(int delta) {
+    public String getCurrentStateDiffStringByDelta(int delta) {
         StateNode prev = statePath.getNode(statePath.getPosition() - delta);
         return statePath.getCurNode().getDiffString(prev);
     }

--- a/src/simulation/SimulationManager.java
+++ b/src/simulation/SimulationManager.java
@@ -54,7 +54,7 @@ public class SimulationManager {
         constraintManager = new ConstraintManager();
 
         traceMode = false;
-        diffMode = false;
+        diffMode = true;
     }
 
     public boolean isTrace() {

--- a/src/simulation/SimulationManager.java
+++ b/src/simulation/SimulationManager.java
@@ -41,6 +41,7 @@ public class SimulationManager {
     private ConstraintManager constraintManager;
 
     private boolean traceMode;
+    private boolean diffMode;  // Whether differential output is enabled.
 
     public SimulationManager() {
         scopes = new TreeMap<>();
@@ -53,10 +54,19 @@ public class SimulationManager {
         constraintManager = new ConstraintManager();
 
         traceMode = false;
+        diffMode = false;
     }
 
     public boolean isTrace() {
         return traceMode;
+    }
+
+    public void setDiffMode(boolean b) {
+        diffMode = b;
+    }
+
+    public boolean isDiffMode() {
+        return diffMode;
     }
 
     /**
@@ -385,8 +395,9 @@ public class SimulationManager {
         return statePath.getCurNode().stringForProperty(property);
     }
 
-    public String getCurrentStateDiffString() {
-        return statePath.getCurNode().getDiffString(statePath.getPrevNode());
+    public String getCurrentStateDiffString(int delta) {
+        StateNode prev = statePath.getNode(statePath.getPosition() - delta);
+        return statePath.getCurNode().getDiffString(prev);
     }
 
     public AliasManager getAliasManager() {

--- a/src/simulation/SimulationManager.java
+++ b/src/simulation/SimulationManager.java
@@ -395,6 +395,21 @@ public class SimulationManager {
         return statePath.getCurNode().stringForProperty(property);
     }
 
+    /**
+     * getCurrentStateDiffString returns the diff between the current and the previous last-committed state.
+     * @return String
+     */
+    public String getCurrentStateDiffString() {
+        StateNode prev = statePath.getNode(statePath.getPosition() - statePath.getTempPathSize());
+        return statePath.getCurNode().getDiffString(prev);
+    }
+
+    /**
+     * getCurrentStateDiffString returns the diff between the current state and the state at the
+     * (current - delta) position in the path.
+     * @param int delta
+     * @return String
+     */
     public String getCurrentStateDiffString(int delta) {
         StateNode prev = statePath.getNode(statePath.getPosition() - delta);
         return statePath.getCurNode().getDiffString(prev);

--- a/src/state/StatePath.java
+++ b/src/state/StatePath.java
@@ -9,7 +9,6 @@ import java.util.List;
 public class StatePath {
     private List<StateNode> path;
     int tempPathSize;
-    private StateNode prev;
     private int position;
 
     public StatePath() {
@@ -47,12 +46,7 @@ public class StatePath {
         return path.isEmpty() ? null : path.get(position);
     }
 
-    public StateNode getPrevNode() {
-        return prev;
-    }
-
     public void setPosition(int position) {
-        prev = getCurNode();
         this.position = position;
     }
 
@@ -67,15 +61,9 @@ public class StatePath {
     public void decrementPosition(int steps, boolean traceMode) {
         int newPos = position < steps ? 0 : position - steps;
         setPosition(newPos);
-        if (position == 0) {
-            prev = null;
-        } else {
-            prev = path.get(position - 1);
+        if (!traceMode) {
+            path = path.subList(0, newPos + 1);
         }
-        if (traceMode) {
-            return;
-        }
-        path = path.subList(0, newPos + 1);
     }
 
     public void commitNodes() {

--- a/src/state/StatePath.java
+++ b/src/state/StatePath.java
@@ -54,6 +54,10 @@ public class StatePath {
         return position;
     }
 
+    public int getTempPathSize() {
+        return tempPathSize;
+    }
+
     public void incrementPosition(int steps) {
         setPosition(position + steps);
     }

--- a/test/commands/TestAltCommand.java
+++ b/test/commands/TestAltCommand.java
@@ -53,6 +53,22 @@ public class TestAltCommand extends TestCommand {
     }
 
     @Test
+    public void testExecute_diffMode() {
+        setupStreams();
+        String res = "Response";
+        when(simulationManager.isInitialized()).thenReturn(true);
+        when(simulationManager.selectAlternatePath(anyBoolean())).thenReturn(true);
+        when(simulationManager.isDiffMode()).thenReturn(true);
+        when(simulationManager.getCurrentStateDiffString(1)).thenReturn(res);
+
+        String[] input = {"alt"};
+        alt.execute(input, simulationManager);
+        verify(simulationManager).getCurrentStateDiffString(1);
+        assertEquals(res + "\n", outContent.toString());
+        restoreStreams();
+    }
+
+    @Test
     public void testExecute_invalidInput() {
         setupStreams();
         when(simulationManager.isInitialized()).thenReturn(true);

--- a/test/commands/TestAltCommand.java
+++ b/test/commands/TestAltCommand.java
@@ -43,27 +43,28 @@ public class TestAltCommand extends TestCommand {
         String res = "Response";
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.selectAlternatePath(anyBoolean())).thenReturn(true);
-        when(simulationManager.getCurrentStateString()).thenReturn(res);
-
-        String[] input = {"alt"};
-        alt.execute(input, simulationManager);
-        verify(simulationManager).getCurrentStateString();
-        assertEquals(res + "\n", outContent.toString());
-        restoreStreams();
-    }
-
-    @Test
-    public void testExecute_diffMode() {
-        setupStreams();
-        String res = "Response";
-        when(simulationManager.isInitialized()).thenReturn(true);
-        when(simulationManager.selectAlternatePath(anyBoolean())).thenReturn(true);
         when(simulationManager.isDiffMode()).thenReturn(true);
         when(simulationManager.getCurrentStateDiffString(1)).thenReturn(res);
 
         String[] input = {"alt"};
         alt.execute(input, simulationManager);
         verify(simulationManager).getCurrentStateDiffString(1);
+        assertEquals(res + "\n", outContent.toString());
+        restoreStreams();
+    }
+
+    @Test
+    public void testExecute_diffModeOff() {
+        setupStreams();
+        String res = "Response";
+        when(simulationManager.isInitialized()).thenReturn(true);
+        when(simulationManager.selectAlternatePath(anyBoolean())).thenReturn(true);
+        when(simulationManager.isDiffMode()).thenReturn(false);
+        when(simulationManager.getCurrentStateString()).thenReturn(res);
+
+        String[] input = {"alt"};
+        alt.execute(input, simulationManager);
+        verify(simulationManager).getCurrentStateString();
         assertEquals(res + "\n", outContent.toString());
         restoreStreams();
     }

--- a/test/commands/TestAltCommand.java
+++ b/test/commands/TestAltCommand.java
@@ -44,11 +44,11 @@ public class TestAltCommand extends TestCommand {
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.selectAlternatePath(anyBoolean())).thenReturn(true);
         when(simulationManager.isDiffMode()).thenReturn(true);
-        when(simulationManager.getCurrentStateDiffString(1)).thenReturn(res);
+        when(simulationManager.getCurrentStateDiffString()).thenReturn(res);
 
         String[] input = {"alt"};
         alt.execute(input, simulationManager);
-        verify(simulationManager).getCurrentStateDiffString(1);
+        verify(simulationManager).getCurrentStateDiffString();
         assertEquals(res + "\n", outContent.toString());
         restoreStreams();
     }

--- a/test/commands/TestAltCommand.java
+++ b/test/commands/TestAltCommand.java
@@ -44,11 +44,11 @@ public class TestAltCommand extends TestCommand {
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.selectAlternatePath(anyBoolean())).thenReturn(true);
         when(simulationManager.isDiffMode()).thenReturn(true);
-        when(simulationManager.getCurrentStateDiffString()).thenReturn(res);
+        when(simulationManager.getCurrentStateDiffStringFromLastCommit()).thenReturn(res);
 
         String[] input = {"alt"};
         alt.execute(input, simulationManager);
-        verify(simulationManager).getCurrentStateDiffString();
+        verify(simulationManager).getCurrentStateDiffStringFromLastCommit();
         assertEquals(res + "\n", outContent.toString());
         restoreStreams();
     }

--- a/test/commands/TestSetCommand.java
+++ b/test/commands/TestSetCommand.java
@@ -129,4 +129,50 @@ public class TestSetCommand extends TestCommand {
         file.delete();
         restoreStreams();
     }
+
+    @Test
+    public void testExecute_setDiffModeNoValue() throws IOException {
+        setupStreams();
+
+        String[] input = {"set", "diff"};
+        set.execute(input, simulationManager);
+        verifyZeroInteractions(simulationManager);
+        assertEquals(set.getHelp() + "\n", outContent.toString());
+
+        restoreStreams();
+    }
+
+    @Test
+    public void testExecute_setDiffModeInvalidValue() throws IOException {
+        setupStreams();
+
+        String[] input = {"set", "diff", "foo"};
+        set.execute(input, simulationManager);
+        verifyZeroInteractions(simulationManager);
+        assertEquals(set.getHelp() + "\n", outContent.toString());
+
+        restoreStreams();
+    }
+
+    @Test
+    public void testExecute_setDiffModeOn() throws IOException {
+        setupStreams();
+
+        String[] input = {"set", "diff", "on"};
+        set.execute(input, simulationManager);
+        verify(simulationManager).setDiffMode(true);
+
+        restoreStreams();
+    }
+
+    @Test
+    public void testExecute_setDiffModeOff() throws IOException {
+        setupStreams();
+
+        String[] input = {"set", "diff", "off"};
+        set.execute(input, simulationManager);
+        verify(simulationManager).setDiffMode(false);
+
+        restoreStreams();
+    }
 }

--- a/test/commands/TestStepCommand.java
+++ b/test/commands/TestStepCommand.java
@@ -174,7 +174,7 @@ public class TestStepCommand extends TestCommand {
         String expectedOutput = String.format(CommandConstants.INVALID_CONSTRAINT, "a") + "\n";
 
         step.execute(rawInput.split(" "), simulationManager);
-        verify(simulationManager, never()).getCurrentStateDiffString(anyInt());
+        verify(simulationManager, never()).getCurrentStateDiffString();
         assertEquals(expectedOutput, outContent.toString());
         restoreStreams();
     }

--- a/test/commands/TestStepCommand.java
+++ b/test/commands/TestStepCommand.java
@@ -173,19 +173,19 @@ public class TestStepCommand extends TestCommand {
     }
 
     @Test
-    public void testExecute_isTrace() {
+    public void testExecute_isDiffMode() {
         setupStreams();
-        String trace = "trace";
+        String state = "state";
         when(simulationManager.isInitialized()).thenReturn(true);
-        when(simulationManager.isTrace()).thenReturn(true);
+        when(simulationManager.isDiffMode()).thenReturn(true);
         when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
-        when(simulationManager.getCurrentStateDiffString()).thenReturn(trace);
+        when(simulationManager.getCurrentStateDiffString(3)).thenReturn(state);
 
         String[] input = {"s", "3"};
         step.execute(input, simulationManager);
         verify(simulationManager).performStep(3, new ArrayList<String>());
-        verify(simulationManager).getCurrentStateDiffString();
-        assertEquals(trace + "\n", outContent.toString());
+        verify(simulationManager).getCurrentStateDiffString(3);
+        assertEquals(state + "\n", outContent.toString());
         restoreStreams();
     }
 

--- a/test/commands/TestStepCommand.java
+++ b/test/commands/TestStepCommand.java
@@ -42,14 +42,17 @@ public class TestStepCommand extends TestCommand {
     public void testExecute_integer() {
         setupStreams();
         String state = "state";
+        int expectedSteps = 3;
+
         when(simulationManager.isInitialized()).thenReturn(true);
-        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
-        when(simulationManager.getCurrentStateString()).thenReturn(state);
+        when(simulationManager.performStep(eq(expectedSteps), anyList())).thenReturn(true);
+        when(simulationManager.isDiffMode()).thenReturn(true);
+        when(simulationManager.getCurrentStateDiffString(expectedSteps)).thenReturn(state);
 
         String[] input = {"s", "3"};
         step.execute(input, simulationManager);
-        verify(simulationManager).performStep(3, new ArrayList<String>());
-        verify(simulationManager).getCurrentStateString();
+        verify(simulationManager).performStep(expectedSteps, new ArrayList<String>());
+        verify(simulationManager).getCurrentStateDiffString(expectedSteps);
         assertEquals(state + "\n", outContent.toString());
         restoreStreams();
     }
@@ -58,22 +61,23 @@ public class TestStepCommand extends TestCommand {
     public void testExecute_constraints() {
         setupStreams();
         String state = "state";
+        int expectedSteps = 4;
 
-        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
+        when(simulationManager.performStep(eq(expectedSteps), anyList())).thenReturn(true);
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.getAliasManager()).thenReturn(am);
-        when(simulationManager.getCurrentStateString()).thenReturn(state);
+        when(simulationManager.isDiffMode()).thenReturn(true);
+        when(simulationManager.getCurrentStateDiffString(expectedSteps)).thenReturn(state);
         when(simulationManager.validateConstraint(anyString())).thenReturn(true);
 
         String rawInput = "s [a, \"b and c\", d, \"e\"]";
-        int expectedSteps = 4;
         List<String> expectedConstraints = new ArrayList<String>(
             Arrays.asList("a", "b and c", "d", "e")
         );
 
         step.execute(rawInput.split(" "), simulationManager);
         verify(simulationManager).performStep(expectedSteps, expectedConstraints);
-        verify(simulationManager).getCurrentStateString();
+        verify(simulationManager).getCurrentStateDiffString(expectedSteps);
         assertEquals(state + "\n", outContent.toString());
         restoreStreams();
     }
@@ -82,22 +86,23 @@ public class TestStepCommand extends TestCommand {
     public void testExecute_constraintsEmpty() {
         setupStreams();
         String state = "state";
+        int expectedSteps = 1;
 
-        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
+        when(simulationManager.performStep(eq(expectedSteps), anyList())).thenReturn(true);
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.getAliasManager()).thenReturn(am);
-        when(simulationManager.getCurrentStateString()).thenReturn(state);
+        when(simulationManager.isDiffMode()).thenReturn(true);
+        when(simulationManager.getCurrentStateDiffString(expectedSteps)).thenReturn(state);
         when(simulationManager.validateConstraint(anyString())).thenReturn(true);
 
         String rawInput = "s []";
-        int expectedSteps = 1;
         List<String> expectedConstraints = new ArrayList<String>(
             Arrays.asList("")
         );
 
         step.execute(rawInput.split(" "), simulationManager);
         verify(simulationManager).performStep(expectedSteps, expectedConstraints);
-        verify(simulationManager).getCurrentStateString();
+        verify(simulationManager).getCurrentStateDiffString(expectedSteps);
         assertEquals(state + "\n", outContent.toString());
         restoreStreams();
     }
@@ -106,22 +111,23 @@ public class TestStepCommand extends TestCommand {
     public void testExecute_constraintsBlank() {
         setupStreams();
         String state = "state";
+        int expectedSteps = 5;
 
-        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
+        when(simulationManager.performStep(eq(expectedSteps), anyList())).thenReturn(true);
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.getAliasManager()).thenReturn(am);
-        when(simulationManager.getCurrentStateString()).thenReturn(state);
+        when(simulationManager.isDiffMode()).thenReturn(true);
+        when(simulationManager.getCurrentStateDiffString(expectedSteps)).thenReturn(state);
         when(simulationManager.validateConstraint(anyString())).thenReturn(true);
 
         String rawInput = "s [\"\", ,, \"\",]";
-        int expectedSteps = 5;
         List<String> expectedConstraints = new ArrayList<String>(
             Arrays.asList("", "", "", "", "")
         );
 
         step.execute(rawInput.split(" "), simulationManager);
         verify(simulationManager).performStep(expectedSteps, expectedConstraints);
-        verify(simulationManager).getCurrentStateString();
+        verify(simulationManager).getCurrentStateDiffString(expectedSteps);
         assertEquals(state + "\n", outContent.toString());
         restoreStreams();
     }
@@ -130,25 +136,26 @@ public class TestStepCommand extends TestCommand {
     public void testExecute_constraintsAlias() {
         setupStreams();
         String state = "state";
+        int expectedSteps = 1;
 
-        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
+        when(simulationManager.performStep(eq(expectedSteps), anyList())).thenReturn(true);
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.getAliasManager()).thenReturn(am);
-        when(simulationManager.getCurrentStateString()).thenReturn(state);
+        when(simulationManager.isDiffMode()).thenReturn(true);
+        when(simulationManager.getCurrentStateDiffString(expectedSteps)).thenReturn(state);
         when(simulationManager.validateConstraint(anyString())).thenReturn(true);
 
         when(am.isAlias(anyString())).thenReturn(true);
         when(am.getFormula(anyString())).thenReturn("a");
 
         String rawInput = "s [f1]";
-        int expectedSteps = 1;
         List<String> expectedConstraints = new ArrayList<String>(
             Arrays.asList("a")
         );
 
         step.execute(rawInput.split(" "), simulationManager);
         verify(simulationManager).performStep(expectedSteps, expectedConstraints);
-        verify(simulationManager).getCurrentStateString();
+        verify(simulationManager).getCurrentStateDiffString(expectedSteps);
         assertEquals(state + "\n", outContent.toString());
         restoreStreams();
     }
@@ -158,33 +165,35 @@ public class TestStepCommand extends TestCommand {
         setupStreams();
         String state = "state";
 
-        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
+        when(simulationManager.performStep(eq(1), anyList())).thenReturn(true);
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.getAliasManager()).thenReturn(am);
-        when(simulationManager.getCurrentStateString()).thenReturn(state);
         when(simulationManager.validateConstraint(anyString())).thenReturn(false);
 
         String rawInput = "s [a]";
         String expectedOutput = String.format(CommandConstants.INVALID_CONSTRAINT, "a") + "\n";
 
         step.execute(rawInput.split(" "), simulationManager);
+        verify(simulationManager, never()).getCurrentStateDiffString(anyInt());
         assertEquals(expectedOutput, outContent.toString());
         restoreStreams();
     }
 
     @Test
-    public void testExecute_isDiffMode() {
+    public void testExecute_diffModeOff() {
         setupStreams();
         String state = "state";
+        int expectedSteps = 3;
+
         when(simulationManager.isInitialized()).thenReturn(true);
-        when(simulationManager.isDiffMode()).thenReturn(true);
-        when(simulationManager.performStep(anyInt(), anyList())).thenReturn(true);
-        when(simulationManager.getCurrentStateDiffString(3)).thenReturn(state);
+        when(simulationManager.performStep(eq(expectedSteps), anyList())).thenReturn(true);
+        when(simulationManager.isDiffMode()).thenReturn(false);
+        when(simulationManager.getCurrentStateString()).thenReturn(state);
 
         String[] input = {"s", "3"};
         step.execute(input, simulationManager);
-        verify(simulationManager).performStep(3, new ArrayList<String>());
-        verify(simulationManager).getCurrentStateDiffString(3);
+        verify(simulationManager).performStep(expectedSteps, new ArrayList<String>());
+        verify(simulationManager).getCurrentStateString();
         assertEquals(state + "\n", outContent.toString());
         restoreStreams();
     }

--- a/test/commands/TestStepCommand.java
+++ b/test/commands/TestStepCommand.java
@@ -47,12 +47,12 @@ public class TestStepCommand extends TestCommand {
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.performStep(eq(expectedSteps), anyList())).thenReturn(true);
         when(simulationManager.isDiffMode()).thenReturn(true);
-        when(simulationManager.getCurrentStateDiffString(expectedSteps)).thenReturn(state);
+        when(simulationManager.getCurrentStateDiffStringByDelta(expectedSteps)).thenReturn(state);
 
         String[] input = {"s", "3"};
         step.execute(input, simulationManager);
         verify(simulationManager).performStep(expectedSteps, new ArrayList<String>());
-        verify(simulationManager).getCurrentStateDiffString(expectedSteps);
+        verify(simulationManager).getCurrentStateDiffStringByDelta(expectedSteps);
         assertEquals(state + "\n", outContent.toString());
         restoreStreams();
     }
@@ -67,7 +67,7 @@ public class TestStepCommand extends TestCommand {
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.getAliasManager()).thenReturn(am);
         when(simulationManager.isDiffMode()).thenReturn(true);
-        when(simulationManager.getCurrentStateDiffString(expectedSteps)).thenReturn(state);
+        when(simulationManager.getCurrentStateDiffStringByDelta(expectedSteps)).thenReturn(state);
         when(simulationManager.validateConstraint(anyString())).thenReturn(true);
 
         String rawInput = "s [a, \"b and c\", d, \"e\"]";
@@ -77,7 +77,7 @@ public class TestStepCommand extends TestCommand {
 
         step.execute(rawInput.split(" "), simulationManager);
         verify(simulationManager).performStep(expectedSteps, expectedConstraints);
-        verify(simulationManager).getCurrentStateDiffString(expectedSteps);
+        verify(simulationManager).getCurrentStateDiffStringByDelta(expectedSteps);
         assertEquals(state + "\n", outContent.toString());
         restoreStreams();
     }
@@ -92,7 +92,7 @@ public class TestStepCommand extends TestCommand {
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.getAliasManager()).thenReturn(am);
         when(simulationManager.isDiffMode()).thenReturn(true);
-        when(simulationManager.getCurrentStateDiffString(expectedSteps)).thenReturn(state);
+        when(simulationManager.getCurrentStateDiffStringByDelta(expectedSteps)).thenReturn(state);
         when(simulationManager.validateConstraint(anyString())).thenReturn(true);
 
         String rawInput = "s []";
@@ -102,7 +102,7 @@ public class TestStepCommand extends TestCommand {
 
         step.execute(rawInput.split(" "), simulationManager);
         verify(simulationManager).performStep(expectedSteps, expectedConstraints);
-        verify(simulationManager).getCurrentStateDiffString(expectedSteps);
+        verify(simulationManager).getCurrentStateDiffStringByDelta(expectedSteps);
         assertEquals(state + "\n", outContent.toString());
         restoreStreams();
     }
@@ -117,7 +117,7 @@ public class TestStepCommand extends TestCommand {
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.getAliasManager()).thenReturn(am);
         when(simulationManager.isDiffMode()).thenReturn(true);
-        when(simulationManager.getCurrentStateDiffString(expectedSteps)).thenReturn(state);
+        when(simulationManager.getCurrentStateDiffStringByDelta(expectedSteps)).thenReturn(state);
         when(simulationManager.validateConstraint(anyString())).thenReturn(true);
 
         String rawInput = "s [\"\", ,, \"\",]";
@@ -127,7 +127,7 @@ public class TestStepCommand extends TestCommand {
 
         step.execute(rawInput.split(" "), simulationManager);
         verify(simulationManager).performStep(expectedSteps, expectedConstraints);
-        verify(simulationManager).getCurrentStateDiffString(expectedSteps);
+        verify(simulationManager).getCurrentStateDiffStringByDelta(expectedSteps);
         assertEquals(state + "\n", outContent.toString());
         restoreStreams();
     }
@@ -142,7 +142,7 @@ public class TestStepCommand extends TestCommand {
         when(simulationManager.isInitialized()).thenReturn(true);
         when(simulationManager.getAliasManager()).thenReturn(am);
         when(simulationManager.isDiffMode()).thenReturn(true);
-        when(simulationManager.getCurrentStateDiffString(expectedSteps)).thenReturn(state);
+        when(simulationManager.getCurrentStateDiffStringByDelta(expectedSteps)).thenReturn(state);
         when(simulationManager.validateConstraint(anyString())).thenReturn(true);
 
         when(am.isAlias(anyString())).thenReturn(true);
@@ -155,7 +155,7 @@ public class TestStepCommand extends TestCommand {
 
         step.execute(rawInput.split(" "), simulationManager);
         verify(simulationManager).performStep(expectedSteps, expectedConstraints);
-        verify(simulationManager).getCurrentStateDiffString(expectedSteps);
+        verify(simulationManager).getCurrentStateDiffStringByDelta(expectedSteps);
         assertEquals(state + "\n", outContent.toString());
         restoreStreams();
     }
@@ -174,7 +174,7 @@ public class TestStepCommand extends TestCommand {
         String expectedOutput = String.format(CommandConstants.INVALID_CONSTRAINT, "a") + "\n";
 
         step.execute(rawInput.split(" "), simulationManager);
-        verify(simulationManager, never()).getCurrentStateDiffString();
+        verify(simulationManager, never()).getCurrentStateDiffStringByDelta(anyInt());
         assertEquals(expectedOutput, outContent.toString());
         restoreStreams();
     }

--- a/test/e2e/TestScenarios.java
+++ b/test/e2e/TestScenarios.java
@@ -89,7 +89,6 @@ public class TestScenarios {
     public void testTraceFGS() throws Exception {
         runALDB(
             "set conf traces/fgs_conf.yml",
-            "set diff on",
             "trace traces/fgs_counterexample.xml",
             "step",
             "step"
@@ -125,7 +124,6 @@ public class TestScenarios {
         runALDB(
             "load models/switch.als",
             "set conf traces/fgs_conf.yml",
-            "set diff on",
             "trace traces/fgs_counterexample.xml",
             "step",
             "step"
@@ -162,7 +160,6 @@ public class TestScenarios {
         runALDB(
             "load models/musical_chairs.als",
             "set conf traces/fgs_conf.yml",
-            "set diff on",
             "trace traces/fgs_counterexample.xml",
             "step",
             "step"

--- a/test/e2e/TestScenarios.java
+++ b/test/e2e/TestScenarios.java
@@ -89,6 +89,7 @@ public class TestScenarios {
     public void testTraceFGS() throws Exception {
         runALDB(
             "set conf traces/fgs_conf.yml",
+            "set diff on",
             "trace traces/fgs_counterexample.xml",
             "step",
             "step"
@@ -124,6 +125,7 @@ public class TestScenarios {
         runALDB(
             "load models/switch.als",
             "set conf traces/fgs_conf.yml",
+            "set diff on",
             "trace traces/fgs_counterexample.xml",
             "step",
             "step"
@@ -160,6 +162,7 @@ public class TestScenarios {
         runALDB(
             "load models/musical_chairs.als",
             "set conf traces/fgs_conf.yml",
+            "set diff on",
             "trace traces/fgs_counterexample.xml",
             "step",
             "step"

--- a/test/simulation/TestSimulationManager.java
+++ b/test/simulation/TestSimulationManager.java
@@ -919,6 +919,78 @@ public class TestSimulationManager {
         assertFalse(sm.validateConstraint(constraint));
     }
 
+    @Test
+    public void testGetCurrentStateDiffStringFromLastCommit() throws IOException {
+        initializeTestWithModelPath("models/musical_chairs.als");
+        sm.initialize(modelFile, false);
+
+        String expectedDiff = String.join("\n",
+            "",
+            "S1 -> S6",
+            "------------",
+            "chairs: { Chair_0, Chair_1 }",
+            "players: { Player_0, Player_1, Player_3 }",
+            ""
+        );
+        String expectedDiff2 = String.join("\n",
+            "",
+            "S6 -> S9",
+            "------------",
+            "mode: { sitting }",
+            "occupied: { Chair_0->Player_3, Chair_1->Player_0 }",
+            ""
+        );
+        String expectedDiff3 = String.join("\n",
+            "",
+            "S6 -> S10",
+            "------------",
+            "mode: { sitting }",
+            "occupied: { Chair_0->Player_3, Chair_1->Player_1 }",
+            ""
+        );
+
+        assertTrue(sm.performStep(3));
+        assertTrue(sm.selectAlternatePath(false));
+        assertEquals(expectedDiff, sm.getCurrentStateDiffStringFromLastCommit());
+
+        assertTrue(sm.performStep(2));
+        assertTrue(sm.selectAlternatePath(false));
+        assertEquals(expectedDiff2, sm.getCurrentStateDiffStringFromLastCommit());
+
+        assertTrue(sm.selectAlternatePath(false));
+        assertEquals(expectedDiff3, sm.getCurrentStateDiffStringFromLastCommit());
+    }
+
+    @Test
+    public void testGetCurrentStateDiffStringByDelta() throws IOException {
+        initializeTestWithModelPath("models/musical_chairs.als");
+        sm.initialize(modelFile, false);
+
+        String expectedDiff = String.join("\n",
+            "",
+            "S1 -> S2",
+            "------------",
+            "mode: { walking }",
+            ""
+        );
+        String expectedDiff2 = String.join("\n",
+            "",
+            "S2 -> S5",
+            "------------",
+            "chairs: { Chair_0, Chair_2 }",
+            "players: { Player_0, Player_1, Player_3 }",
+            ""
+        );
+
+        int steps = 1;
+        assertTrue(sm.performStep(steps));
+        assertEquals(expectedDiff, sm.getCurrentStateDiffStringByDelta(steps));
+
+        steps = 3;
+        assertTrue(sm.performStep(steps));
+        assertEquals(expectedDiff2, sm.getCurrentStateDiffStringByDelta(steps));
+    }
+
     private void initializeTestWithModelPath(String modelPath) throws IOException {
         File file = new File(modelPath);
         modelFile = tempFolder.newFile(String.format("test_%s.als", file.getName()));

--- a/test/state/TestStatePath.java
+++ b/test/state/TestStatePath.java
@@ -91,21 +91,6 @@ public class TestStatePath {
     }
 
     @Test
-    public void testGetPrevNode() {
-        StatePath sp = new StatePath();
-        assertEquals(null, sp.getPrevNode());
-
-        List<StateNode> path = new ArrayList<StateNode>();
-        path.add(n0);
-        path.add(n1);
-        sp.initWithPath(path);
-        assertEquals(null, sp.getPrevNode());
-
-        sp.setPosition(0);
-        assertEquals(n1, sp.getPrevNode());
-    }
-
-    @Test
     public void testSetAndGetPosition() {
         StatePath sp = new StatePath();
         assertEquals(0, sp.getPosition());
@@ -117,7 +102,6 @@ public class TestStatePath {
         assertEquals(1, sp.getPosition());
 
         sp.setPosition(0);
-        assertEquals(n1, sp.getPrevNode());
         assertEquals(0, sp.getPosition());
     }
 
@@ -136,12 +120,10 @@ public class TestStatePath {
 
         sp.incrementPosition(1);
         assertEquals(1, sp.getPosition());
-        assertEquals(n0, sp.getPrevNode());
         assertFalse(sp.atEnd());
 
         sp.incrementPosition(1);
         assertEquals(2, sp.getPosition());
-        assertEquals(n1, sp.getPrevNode());
         assertTrue(sp.atEnd());
     }
 
@@ -157,7 +139,6 @@ public class TestStatePath {
 
         sp.decrementPosition(1, false);
         assertEquals(1, sp.getPosition());
-        assertEquals(n0, sp.getPrevNode());
         assertEquals(n1, sp.getCurNode());
 
         // Decrement path size 3 by 2.
@@ -166,7 +147,6 @@ public class TestStatePath {
 
         sp.decrementPosition(2, false);
         assertEquals(0, sp.getPosition());
-        assertEquals(null, sp.getPrevNode());
         assertEquals(n0, sp.getCurNode());
 
         // Decrement path size 3 by 3.
@@ -175,7 +155,6 @@ public class TestStatePath {
 
         sp.decrementPosition(3, false);
         assertEquals(0, sp.getPosition());
-        assertEquals(null, sp.getPrevNode());
         assertEquals(n0, sp.getCurNode());
 
         // Decrement path size 3 by 4.
@@ -184,7 +163,6 @@ public class TestStatePath {
 
         sp.decrementPosition(4, false);
         assertEquals(0, sp.getPosition());
-        assertEquals(null, sp.getPrevNode());
         assertEquals(n0, sp.getCurNode());
     }
 
@@ -196,7 +174,6 @@ public class TestStatePath {
         tempPath.add(n1);
         sp.setTempPath(tempPath);
         assertEquals(1, sp.getPosition());
-        assertEquals(null, sp.getPrevNode());
         assertEquals(n1, sp.getCurNode());
     }
 
@@ -211,7 +188,6 @@ public class TestStatePath {
 
         sp.clearTempPath();
         assertEquals(-1, sp.getPosition());
-        assertEquals(null, sp.getPrevNode());
         assertEquals(null, sp.getCurNode());
 
         // Clear temp path with an initial path set.
@@ -220,13 +196,11 @@ public class TestStatePath {
         // Should be a no-op.
         sp.clearTempPath();
         assertEquals(1, sp.getPosition());
-        assertEquals(null, sp.getPrevNode());
         assertEquals(n1, sp.getCurNode());
 
         sp.setTempPath(tempPath);
         sp.clearTempPath();
         assertEquals(1, sp.getPosition());
-        assertEquals(null, sp.getPrevNode());
         assertEquals(n1, sp.getCurNode());
     }
 

--- a/test/state/TestStatePath.java
+++ b/test/state/TestStatePath.java
@@ -175,6 +175,7 @@ public class TestStatePath {
         sp.setTempPath(tempPath);
         assertEquals(1, sp.getPosition());
         assertEquals(n1, sp.getCurNode());
+        assertEquals(tempPath.size(), sp.getTempPathSize());
     }
 
     @Test
@@ -189,6 +190,7 @@ public class TestStatePath {
         sp.clearTempPath();
         assertEquals(-1, sp.getPosition());
         assertEquals(null, sp.getCurNode());
+        assertEquals(0, sp.getTempPathSize());
 
         // Clear temp path with an initial path set.
         sp.initWithPath(tempPath);
@@ -197,11 +199,13 @@ public class TestStatePath {
         sp.clearTempPath();
         assertEquals(1, sp.getPosition());
         assertEquals(n1, sp.getCurNode());
+        assertEquals(0, sp.getTempPathSize());
 
         sp.setTempPath(tempPath);
         sp.clearTempPath();
         assertEquals(1, sp.getPosition());
         assertEquals(n1, sp.getCurNode());
+        assertEquals(0, sp.getTempPathSize());
     }
 
     @Test
@@ -209,6 +213,7 @@ public class TestStatePath {
         StatePath sp = new StatePath();
         sp.clearPath();
         assertTrue(sp.isEmpty());
+        assertEquals(0, sp.getTempPathSize());
 
         List<StateNode> tempPath = new ArrayList<StateNode>();
         tempPath.add(n0);
@@ -218,6 +223,7 @@ public class TestStatePath {
         assertFalse(sp.isEmpty());
         sp.clearPath();
         assertTrue(sp.isEmpty());
+        assertEquals(0, sp.getTempPathSize());
     }
 
     @Test


### PR DESCRIPTION
When enabled, only fields that have changed between the previous and current state will be displayed when using `step` or `alt`.

```
(aldb) help set
Set ALDB options.

Available options:

set conf [filename]

    Set the parsing configuration for the current session.

    The specified file must be in YAML. The following (customizable) properties are set by default:

    # Name of the sig representing the main state in the Alloy model.
    stateSigName: State
    # Name of the predicate which defines the initial state in the Alloy model.
    initPredicateName: init
    # Name of the transition relation in the Alloy model.
    transitionRelationName: next
    # Additional Alloy sig scopes to specify.
    additionalSigScopes: {}

    Running set conf with no filename will set the above default options.

set diff <on | off>

    Turn on/off differential output mode.

    When enabled, only fields that have changed between the previous and current state are displayed when executing step or alt.
    By default, this option is enabled.
(aldb)
```

Closes #39.