### PR TITLE
Fail load when no instance found

### DIFF
--- a/src/simulation/SimulationManager.java
+++ b/src/simulation/SimulationManager.java
@@ -487,6 +487,10 @@ public class SimulationManager {
         }
 
         A4Solution sol = AlloyInterface.run(compModule);
+        if (!sol.satisfiable()) {
+            System.out.println("error. No instance found. Predicate may be inconsistent.");
+            return false;
+        }
 
         evaluateScopes(sol);
 


### PR DESCRIPTION
ALDB can enter an erroneous state where `statePath` is empty after a `load` that did not fail (this happens when `initialNodes` is empty in `initializeWithModel`). As a result, commands such as `step` do not execute because ALDB believes there is no model loaded.

This change also ensures parity with Alloy Analyzer's behaviour:

![image](https://user-images.githubusercontent.com/13262777/82761452-a249ff80-9dc8-11ea-9575-c275e889fe3b.png)

([See code path](https://github.com/AlloyTools/org.alloytools.alloy/blob/1da30a1b2003b7fc95822b81d0094cc14a2e25ae/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/translator/TranslateAlloyToKodkod.java#L470))

Closes #48.