### PR TITLE
Report specific model error on load failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,6 @@ No file specified. | If the command requires a file, specify the file path after
 Failed to read file. | The file exists but could not be read. Restart ALDB and try again.
 Invalid configuration. | Ensure that the configuration is correctly specified in syntactically-valid YAML.
 Invalid trace. | Ensure that the trace file is XML generated directly from the Alloy Analyzer.
-Internal error. Failed to create temporary Alloy file. | Restart ALDB and try again. If this error continues to occur, restart the computer.
 Undefined command. | The command does not exist. Ensure no typos.
 Signature not found. | Ensure that the Sig being requested by the `scope` command exists in the model that was loaded.
 No model file specified. | Use the `load` command to load an Alloy model, and then retry the action.

--- a/README.md
+++ b/README.md
@@ -389,10 +389,10 @@ Signature not found. | Ensure that the Sig being requested by the `scope` comman
 No model file specified. | Use the `load` command to load an Alloy model, and then retry the action.
 Session log could not be opened for reading. | Ensure that the given session log path is correct and the file exists.
 Unable to create session log. | Restart ALDB and try again. If this error continues to occur, restart the computer.
-Could not parse model. | Ensure that the model is written in valid Alloy code. Use the Alloy Analyzer to check.
 Predicate not found. | Ensure that the predicate name specified in the configuration exists in the Alloy model.
 Issue parsing predicate. | Ensure that the Alloy model is syntactically-valid.
 I/O failed, cannot initialize model. | Restart ALDB and try again. If this error continues to occur, restart the computer.
+Internal error. | Ensure that you are using the latest version of ALDB. If the error continues to occur, please [report an issue](#reporting-issues).
 
 ## Reporting Issues
 

--- a/src/alloy/AlloyInterface.java
+++ b/src/alloy/AlloyInterface.java
@@ -33,9 +33,6 @@ public class AlloyInterface {
 
     public static A4Solution run(CompModule module) throws Err {
         List<Command> commands = module.getAllCommands();
-        if (commands.isEmpty()) {
-            return null;
-        }
 
         // Use the command injected by us at the end of the input
         // model. This ensures any extraneous commands in the input model are

--- a/src/alloy/AlloyInterface.java
+++ b/src/alloy/AlloyInterface.java
@@ -31,7 +31,7 @@ public class AlloyInterface {
         return CompUtil.parseEverything_fromFile(reporter, null, modelPath);
     }
 
-    public static A4Solution run(CompModule module) {
+    public static A4Solution run(CompModule module) throws Err {
         List<Command> commands = module.getAllCommands();
         if (commands.isEmpty()) {
             return null;

--- a/src/alloy/AlloyInterface.java
+++ b/src/alloy/AlloyInterface.java
@@ -27,12 +27,8 @@ public class AlloyInterface {
     private static final A4Reporter reporter = new A4Reporter();
     private static final A4Options options = new A4Options();
 
-    public static CompModule compile(String modelPath) {
-        try {
-            return CompUtil.parseEverything_fromFile(reporter, null, modelPath);
-        } catch (Err e) {}
-
-        return null;
+    public static CompModule compile(String modelPath) throws Err {
+        return CompUtil.parseEverything_fromFile(reporter, null, modelPath);
     }
 
     public static A4Solution run(CompModule module) {

--- a/src/commands/CommandConstants.java
+++ b/src/commands/CommandConstants.java
@@ -11,7 +11,6 @@ public class CommandConstants {
     public final static String FAILED_TO_READ_FILE = "error. Failed to read file.";
     public final static String FAILED_TO_READ_CONF = "error. Invalid configuration.";
     public final static String INVALID_TRACE = "error. Invalid trace.";
-    public final static String TMP_FILE_ERROR = "internal error. Failed to create temporary Alloy file.";
     public final static String SETTING_PARSING_OPTIONS = "Setting default parsing options...";
     public final static String SETTING_PARSING_OPTIONS_FROM = "Setting parsing options from %s...";
     public final static String UNDEFINED_COMMAND = "Undefined command: \"%s\". Try \"help\".\n";

--- a/src/commands/LoadCommand.java
+++ b/src/commands/LoadCommand.java
@@ -4,12 +4,8 @@ import alloy.AlloyUtils;
 import simulation.SimulationManager;
 
 import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 
 public class LoadCommand extends Command {
-    private final static String TEMP_FILENAME_PREFIX = "_tmp_";
-
     public String getName() {
         return CommandConstants.LOAD_NAME;
     }
@@ -45,20 +41,7 @@ public class LoadCommand extends Command {
 
         System.out.printf(CommandConstants.READING_MODEL, filename);
 
-        String tempModelFilename = TEMP_FILENAME_PREFIX + file.getName();
-        // Note that the temp model file must be created in the same directory as the input model
-        // in order for Alloy to correctly find imported submodules.
-        File tempModelFile = new File(file.getParentFile(), tempModelFilename);
-        tempModelFile.deleteOnExit();
-
-        try {
-            Files.copy(file.toPath(), tempModelFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        } catch (Exception e) {
-            System.out.println(CommandConstants.TMP_FILE_ERROR);
-            return;
-        }
-
-        if (simulationManager.initialize(tempModelFile, false)) {
+        if (simulationManager.initialize(file, false)) {
             System.out.println(CommandConstants.DONE);
         }
     }

--- a/src/simulation/SimulationManager.java
+++ b/src/simulation/SimulationManager.java
@@ -193,7 +193,8 @@ public class SimulationManager {
             System.out.println("Cannot perform step. Internal error.");
             return false;
         }
-        if (sol == null || !sol.satisfiable()) {
+
+        if (!sol.satisfiable()) {
             System.out.println("Cannot perform step. Transition constraint is unsatisfiable.");
             return false;
         }
@@ -295,9 +296,8 @@ public class SimulationManager {
             } catch (Err e) {
                 return false;
             }
-            if (sol == null) {
-                return false;
-            } else if (!sol.satisfiable()) {
+
+            if (!sol.satisfiable()) {
                 // Breakpoints not hit for current step size. Try next step size.
                 continue;
             }
@@ -360,6 +360,7 @@ public class SimulationManager {
             System.out.println("internal error.");
             return false;
         }
+
         List<StateNode> initialNodes = getStateNodesForA4Solution(sol);
         // We don't re-add this initial node to the StateGraph, so manually set its identifier here.
         initialNodes.get(0).setIdentifier(1);
@@ -574,6 +575,7 @@ public class SimulationManager {
             System.out.printf("error.\n\n%s\n", e.msg.trim());
             return false;
         }
+
         if (!sol.satisfiable()) {
             System.out.println("error. No instance found. Predicate may be inconsistent.");
             return false;

--- a/src/simulation/SimulationManager.java
+++ b/src/simulation/SimulationManager.java
@@ -9,6 +9,10 @@ import alloy.AlloyInterface;
 import alloy.AlloyUtils;
 import alloy.ParsingConf;
 import alloy.SigData;
+
+import edu.mit.csail.sdg.alloy4.Err;
+import edu.mit.csail.sdg.alloy4.ErrorSyntax;
+import edu.mit.csail.sdg.alloy4.ErrorType;
 import edu.mit.csail.sdg.ast.Sig;
 import edu.mit.csail.sdg.parser.CompModule;
 import edu.mit.csail.sdg.translator.A4Solution;
@@ -172,9 +176,11 @@ public class SimulationManager {
             return false;
         }
 
-        CompModule compModule = AlloyInterface.compile(alloyModelFile.getAbsolutePath());
-        if (compModule == null) {
-            System.out.println("Cannot perform step. Could not parse model.");
+        CompModule compModule = null;
+        try {
+            compModule = AlloyInterface.compile(alloyModelFile.getAbsolutePath());
+        } catch (Err e) {
+            System.out.println("Cannot perform step. Internal error.");
             return false;
         }
 
@@ -268,8 +274,10 @@ public class SimulationManager {
                 return false;
             }
 
-            CompModule compModule = AlloyInterface.compile(alloyModelFile.getAbsolutePath());
-            if (compModule == null) {
+            CompModule compModule = null;
+            try {
+                compModule = AlloyInterface.compile(alloyModelFile.getAbsolutePath());
+            } catch (Err e) {
                 return false;
             }
 
@@ -324,9 +332,11 @@ public class SimulationManager {
             return false;
         }
 
-        CompModule compModule = AlloyInterface.compile(alloyModelFile.getAbsolutePath());
-        if (compModule == null) {
-            System.out.println("error. Could not parse model.");
+        CompModule compModule = null;
+        try {
+            compModule = AlloyInterface.compile(alloyModelFile.getAbsolutePath());
+        } catch (Err e) {
+            System.out.println("internal error.");
             return false;
         }
 
@@ -363,8 +373,9 @@ public class SimulationManager {
             return false;
         }
 
-        CompModule compModule = AlloyInterface.compile(alloyModelFile.getAbsolutePath());
-        if (compModule == null) {
+        try {
+            AlloyInterface.compile(alloyModelFile.getAbsolutePath());
+        } catch (Err e) {
             return false;
         }
 
@@ -429,8 +440,16 @@ public class SimulationManager {
     }
 
     private boolean initializeWithModel(File model) {
-        if (AlloyInterface.compile(model.getPath()) == null) {
-            System.out.println("error. Could not parse model.");
+        try {
+            AlloyInterface.compile(model.getPath());
+        } catch (Err e) {
+            String errType = "error";
+            if (e instanceof ErrorSyntax) {
+                errType = "syntax error";
+            } else if (e instanceof ErrorType) {
+                errType = "type error";
+            }
+            System.out.printf("%s. %s\n", errType, e.msg.trim());
             return false;
         }
 
@@ -450,6 +469,12 @@ public class SimulationManager {
                 System.out.println("error. Invalid configuration.");
                 return false;
             }
+        }
+
+        int transRelIndex = modelString.indexOf(String.format("pred %s", getParsingConf().getTransitionRelationName()));
+        if (transRelIndex == -1) {
+            System.out.printf("error. Predicate %s not found.\n", getParsingConf().getTransitionRelationName());
+            return false;
         }
 
         int initStartIndex = modelString.indexOf(String.format("pred %s", getParsingConf().getInitPredicateName()));
@@ -507,9 +532,11 @@ public class SimulationManager {
             return false;
         }
 
-        CompModule compModule = AlloyInterface.compile(model.getAbsolutePath());
-        if (compModule == null) {
-            System.out.println("error. Could not parse model.");
+        CompModule compModule = null;
+        try {
+            compModule = AlloyInterface.compile(model.getAbsolutePath());
+        } catch (Err e) {
+            System.out.println("internal error.");
             return false;
         }
 

--- a/src/simulation/SimulationManager.java
+++ b/src/simulation/SimulationManager.java
@@ -11,8 +11,6 @@ import alloy.ParsingConf;
 import alloy.SigData;
 
 import edu.mit.csail.sdg.alloy4.Err;
-import edu.mit.csail.sdg.alloy4.ErrorSyntax;
-import edu.mit.csail.sdg.alloy4.ErrorType;
 import edu.mit.csail.sdg.ast.Sig;
 import edu.mit.csail.sdg.parser.CompModule;
 import edu.mit.csail.sdg.translator.A4Solution;
@@ -573,7 +571,7 @@ public class SimulationManager {
         try {
             sol = AlloyInterface.run(compModule);
         } catch (Err e) {
-            System.out.printf("error.\n\n%s\n", e.toString());
+            System.out.printf("error.\n\n%s\n", e.msg.trim());
             return false;
         }
         if (!sol.satisfiable()) {

--- a/test/alloy/TestAlloyInterface.java
+++ b/test/alloy/TestAlloyInterface.java
@@ -1,5 +1,6 @@
 package alloy;
 
+import edu.mit.csail.sdg.alloy4.Err;
 import edu.mit.csail.sdg.ast.Sig;
 import edu.mit.csail.sdg.translator.A4Solution;
 
@@ -34,12 +35,16 @@ public class TestAlloyInterface {
         String invalidCode = "}{";
         appendToFile(model, invalidCode);
 
-        assertNull(AlloyInterface.compile(model.getPath()));
+        assertThrows(Err.class, () -> {
+            AlloyInterface.compile(model.getPath());
+        });
     }
 
     @Test
-    public void testCompile_failureNoFile() throws IOException {
-        assertNull(AlloyInterface.compile("non-existant-file"));
+    public void testCompile_failureNoFile() {
+        assertThrows(Err.class, () -> {
+            AlloyInterface.compile("non-existant-file");
+        });
     }
 
     @Test

--- a/test/simulation/TestSimulationManager.java
+++ b/test/simulation/TestSimulationManager.java
@@ -67,6 +67,7 @@ public class TestSimulationManager {
         File nonexistantFile = new File("nonexistant-file");
         assertFalse(sm.initialize(nonexistantFile, false));
         assertFalse(sm.isInitialized());
+        assertTrue(outContent.toString().contains("syntax error"));
     }
 
     @Test
@@ -79,6 +80,7 @@ public class TestSimulationManager {
         initializeTestWithModelString(noInitModel);
         assertFalse(sm.initialize(modelFile, false));
         assertFalse(sm.isInitialized());
+        assertTrue(outContent.toString().contains("init not found"));
     }
 
     @Test
@@ -91,6 +93,7 @@ public class TestSimulationManager {
         initializeTestWithModelString(noNextModel);
         assertFalse(sm.initialize(modelFile, false));
         assertFalse(sm.isInitialized());
+        assertTrue(outContent.toString().contains("next not found"));
     }
 
     @Test
@@ -103,6 +106,7 @@ public class TestSimulationManager {
         initializeTestWithModelString(invalidModel);
         assertFalse(sm.initialize(modelFile, false));
         assertFalse(sm.isInitialized());
+        assertTrue(outContent.toString().contains("syntax error"));
     }
 
     @Test

--- a/test/simulation/TestSimulationManager.java
+++ b/test/simulation/TestSimulationManager.java
@@ -67,7 +67,7 @@ public class TestSimulationManager {
         File nonexistantFile = new File("nonexistant-file");
         assertFalse(sm.initialize(nonexistantFile, false));
         assertFalse(sm.isInitialized());
-        assertTrue(outContent.toString().contains("syntax error"));
+        assertTrue(outContent.toString().contains("Syntax error"));
     }
 
     @Test
@@ -106,7 +106,23 @@ public class TestSimulationManager {
         initializeTestWithModelString(invalidModel);
         assertFalse(sm.initialize(modelFile, false));
         assertFalse(sm.isInitialized());
-        assertTrue(outContent.toString().contains("syntax error"));
+        assertTrue(outContent.toString().contains("Syntax error"));
+    }
+
+    @Test
+    public void testInitializeWithModel_missingScopes() throws IOException {
+        String model = String.join("\n",
+            "sig Foo {}",
+            "sig State { x: set Foo }",
+            "pred init[s: State] {}",
+            "pred next[s, s': State] {}",
+            ""
+        );
+        initializeTestWithModelString(model);
+        assertFalse(sm.initialize(modelFile, false));
+        assertFalse(sm.isInitialized());
+        assertTrue(outContent.toString().contains("Syntax error"));
+        assertTrue(outContent.toString().contains("must specify a scope"));
     }
 
     @Test

--- a/test/simulation/TestSimulationManager.java
+++ b/test/simulation/TestSimulationManager.java
@@ -121,8 +121,7 @@ public class TestSimulationManager {
         initializeTestWithModelString(model);
         assertFalse(sm.initialize(modelFile, false));
         assertFalse(sm.isInitialized());
-        assertTrue(outContent.toString().contains("Syntax error"));
-        assertTrue(outContent.toString().contains("must specify a scope"));
+        assertTrue(outContent.toString().contains("must specify a scope for sig \"this/Foo\""));
     }
 
     @Test


### PR DESCRIPTION
Having ALDB output a more meaningful error message upon a failed load saves the user the effort of having to cross-check with the Alloy Analyzer for the exact issue with their model.

From the Analyzer:
![image](https://user-images.githubusercontent.com/13262777/83290246-5b874b80-a1b4-11ea-837a-9029a3be08b2.png)


In ALDB:
```
(aldb) load ../DigitalWatch.als
Reading model from ../DigitalWatch.als...error.

Syntax error:
File cannot be found.
/<path>/<to>/<dir>/util/ctl.als (No such file or directory)
(aldb)
```

```
(aldb) load ../DigitalWatch.als
Reading model from ../DigitalWatch.als...error.

Syntax error in /<path>/<to>/<dir>/DigitalWatch.als at line 1499 column 21:
The name "imp_" cannot be found.
(aldb)
```

Note that sections I've marked as "internal errors" should only be reached due to misimplementation on our end or rare fatal errors (for example, I/O).

Relevant Alloy code paths: [(1)](https://github.com/AlloyTools/org.alloytools.alloy/blob/1da30a1b2003b7fc95822b81d0094cc14a2e25ae/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/ErrorSyntax.java#L59) [(2)](https://github.com/AlloyTools/org.alloytools.alloy/blob/master/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/parser/CompUtil.java#L361)

Closes #50.