### PR TITLE
Support tab completion of set command options and values

### DIFF
--- a/src/commands/Command.java
+++ b/src/commands/Command.java
@@ -2,6 +2,8 @@ package commands;
 
 import simulation.SimulationManager;
 
+import org.jline.reader.Completer;
+
 public abstract class Command {
     private final static String[] SHORTHAND = {};
 
@@ -17,5 +19,9 @@ public abstract class Command {
 
     public boolean requiresFile() {
         return false;
+    }
+
+    public Completer getSpecialCompleter() {
+        return null;
     }
 }

--- a/src/commands/SetCommand.java
+++ b/src/commands/SetCommand.java
@@ -8,7 +8,12 @@ import java.io.IOException;
 import java.io.File;
 import java.nio.file.Files;
 
+import org.jline.builtins.Completers.FileNameCompleter;
+import org.jline.builtins.Completers.TreeCompleter;
+import org.jline.reader.Completer;
 import org.yaml.snakeyaml.error.YAMLException;
+
+import static org.jline.builtins.Completers.TreeCompleter.node;
 
 public class SetCommand extends Command {
     private final static String CONF_OPTION = "conf";
@@ -27,6 +32,15 @@ public class SetCommand extends Command {
 
     public String getHelp() {
         return CommandConstants.SET_HELP;
+    }
+
+    public Completer getSpecialCompleter() {
+        return new TreeCompleter(
+            node(getName(),
+                node(CONF_OPTION,
+                    node(new FileNameCompleter())),
+                node(DIFF_OPTION,
+                    node(ON, OFF))));
     }
 
     public void execute(String[] input, SimulationManager simulationManager) {


### PR DESCRIPTION
Ex.

![image](https://user-images.githubusercontent.com/13262777/83667831-045eed80-a59d-11ea-9c0e-b15298ad2c50.png)

![image](https://user-images.githubusercontent.com/13262777/83667783-f27d4a80-a59c-11ea-8c0f-1ee836a1be51.png)

Note that this change also implements the ability for us to add completers on a per-command basis for any commands which may require an advanced completer.

Closes #52.