### PR TITLE
Simplify parsing of trace to A4Solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,6 @@ No such file. | Ensure that the file exists, and that the file path being provid
 No file specified. | If the command requires a file, specify the file path after the command name.
 Failed to read file. | The file exists but could not be read. Restart ALDB and try again.
 Invalid configuration. | Ensure that the configuration is correctly specified in syntactically-valid YAML.
-Invalid trace. | Ensure that the trace file is XML generated directly from the Alloy Analyzer.
 Undefined command. | The command does not exist. Ensure no typos.
 Signature not found. | Ensure that the Sig being requested by the `scope` command exists in the model that was loaded.
 No model file specified. | Use the `load` command to load an Alloy model, and then retry the action.

--- a/src/alloy/AlloyConstants.java
+++ b/src/alloy/AlloyConstants.java
@@ -13,9 +13,6 @@ public class AlloyConstants {
     public static final String BLOCK_TERMINATOR = "}";
     public static final String INT = "Int";
     public static final String NONE = "none";
-    public static final String TRACE_SOURCE_TAG = "source";
-    public static final String TRACE_FILENAME_ATTR = "filename";
-    public static final String TRACE_CONTENT_ATTR = "content";
     public static final String PATH_AUXILIARY_PREDICATE_FORMAT = "state_s%d";
     public static final String PATH_PREDICATE_NAME = "path";
     public static final String PLUS = "+";

--- a/src/alloy/AlloyInterface.java
+++ b/src/alloy/AlloyInterface.java
@@ -14,12 +14,7 @@ import edu.mit.csail.sdg.translator.A4SolutionReader;
 import edu.mit.csail.sdg.translator.A4TupleSet;
 import edu.mit.csail.sdg.translator.TranslateAlloyToKodkod;
 
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,51 +38,13 @@ public class AlloyInterface {
     }
 
     /**
-     * solutionFromXMLFile reads an Alloy XML file and returns an A4Solution
-     * using the Alloy API. The root model and all included files are obtained
-     * from the XML file and saved to disk, as required by the API.
+     * solutionFromXMLFile reads an Alloy XML file and returns an A4Solution.
      * @param File
      * @return A4Solution
+     * @throws Exception if reading the file or converting it to an A4Solution failed.
      */
     public static A4Solution solutionFromXMLFile(File file) throws Exception {
-        Path tempDir = Files.createTempDirectory("aldb");
-
-        XMLNode root = new XMLNode(file);
-
-        // The first source file is the root module.
-        String alloySourceFilename = root.getChildren(AlloyConstants.TRACE_SOURCE_TAG)
-                                         .iterator()
-                                         .next()
-                                         .getAttribute(AlloyConstants.TRACE_FILENAME_ATTR);
-
-        for (XMLNode node : root) {
-            if (node.is(AlloyConstants.TRACE_SOURCE_TAG)) {
-                String sourceFilename = node.getAttribute(AlloyConstants.TRACE_FILENAME_ATTR);
-                Path sourceFilenamePath = Paths.get(sourceFilename);
-                Path mainFilePath = Paths.get(alloySourceFilename).getParent();
-                sourceFilenamePath = mainFilePath.relativize(sourceFilenamePath);
-
-                // Don't include Alloy standard library files.
-                if (sourceFilenamePath.startsWith("../")) {
-                    continue;
-                }
-
-                File outFile = tempDir.resolve(sourceFilenamePath).toFile();
-                if (outFile.getParentFile() != null) {
-                    outFile.getParentFile().mkdirs();
-                }
-
-                String sourceFileContents = node.getAttribute(AlloyConstants.TRACE_CONTENT_ATTR);
-                AlloyUtils.writeToFile(sourceFileContents, outFile);
-            }
-        }
-
-        alloySourceFilename = tempDir.resolve(Paths.get(alloySourceFilename).getFileName()).toString();
-
-        // Parse from a file rather than a string in order to support includes.
-        CompModule module = CompUtil.parseEverything_fromFile(reporter, null, alloySourceFilename);
-
-        return A4SolutionReader.read(module.getAllReachableSigs(), root);
+        return A4SolutionReader.read(new ArrayList<Sig>(), new XMLNode(file));
     }
 
     public static Sig getSigFromA4Solution(A4Solution sol, String sigName) {

--- a/src/commands/CommandConstants.java
+++ b/src/commands/CommandConstants.java
@@ -10,7 +10,6 @@ public class CommandConstants {
     public final static String IO_FAILED = "error. I/O failed.";
     public final static String FAILED_TO_READ_FILE = "error. Failed to read file.";
     public final static String FAILED_TO_READ_CONF = "error. Invalid configuration.";
-    public final static String INVALID_TRACE = "error. Invalid trace.";
     public final static String SETTING_PARSING_OPTIONS = "Setting default parsing options...";
     public final static String SETTING_PARSING_OPTIONS_FROM = "Setting parsing options from %s...";
     public final static String UNDEFINED_COMMAND = "Undefined command: \"%s\". Try \"help\".\n";

--- a/src/commands/TraceCommand.java
+++ b/src/commands/TraceCommand.java
@@ -42,11 +42,8 @@ public class TraceCommand extends Command {
 
         System.out.printf(CommandConstants.READING_TRACE, filename);
 
-        if (!simulationManager.initialize(file, true)) {
-            System.out.println(CommandConstants.INVALID_TRACE);
-            return;
+        if (simulationManager.initialize(file, true)) {
+            System.out.println(CommandConstants.DONE);
         }
-
-        System.out.println(CommandConstants.DONE);
     }
 }

--- a/src/simulation/SimulationManager.java
+++ b/src/simulation/SimulationManager.java
@@ -607,7 +607,13 @@ public class SimulationManager {
         A4Solution sol;
         try {
             sol = AlloyInterface.solutionFromXMLFile(trace);
-        } catch (Exception e) {
+        } catch (Exception ex) {
+            if (ex instanceof Err) {
+                Err err = (Err) ex;
+                System.out.printf("error.\n\n%s\n", err.toString());
+            } else {
+                System.out.println("error. Could not read XML file.");
+            }
             return false;
         }
 
@@ -623,6 +629,7 @@ public class SimulationManager {
 
         List<StateNode> stateNodes = getStateNodesForA4Solution(sol);
         if (stateNodes.isEmpty()) {
+            System.out.println("internal error.");
             return false;
         }
 

--- a/src/simulation/SimulationManager.java
+++ b/src/simulation/SimulationManager.java
@@ -607,13 +607,11 @@ public class SimulationManager {
         A4Solution sol;
         try {
             sol = AlloyInterface.solutionFromXMLFile(trace);
-        } catch (Exception ex) {
-            if (ex instanceof Err) {
-                Err err = (Err) ex;
-                System.out.printf("error.\n\n%s\n", err.toString());
-            } else {
-                System.out.println("error. Could not read XML file.");
-            }
+        } catch (Err e) {
+            System.out.printf("error.\n\n%s\n", e.toString());
+            return false;
+        } catch (Exception e) {
+            System.out.println("error. Could not read XML file.");
             return false;
         }
 

--- a/test/commands/TestTraceCommand.java
+++ b/test/commands/TestTraceCommand.java
@@ -77,9 +77,8 @@ public class TestTraceCommand extends TestCommand {
 
         String[] input = {"t", file.getPath()};
         trace.execute(input, simulationManager);
-        String msg = String.format(CommandConstants.READING_TRACE, input[1]);
-        msg += CommandConstants.INVALID_TRACE + "\n";
-        assertEquals(msg, outContent.toString());
+        String readingMsg = String.format(CommandConstants.READING_TRACE, input[1]);
+        assertTrue(outContent.toString().contains(readingMsg));
         file.delete();
         restoreStreams();
     }

--- a/test/simulation/TestSimulationManager.java
+++ b/test/simulation/TestSimulationManager.java
@@ -162,6 +162,7 @@ public class TestSimulationManager {
         initializeTestWithModelPath("models/switch.als");
         assertFalse(sm.initialize(modelFile, true));
         assertFalse(sm.isTrace());
+        assertTrue(outContent.toString().contains("error. Could not read XML file."));
     }
 
     @Test


### PR DESCRIPTION
As per the [documentation](http://alloytools.org/documentation/alloy-api/edu/mit/csail/sdg/alloy4compiler/translator/A4SolutionReader.html#read(java.lang.Iterable,%20edu.mit.csail.sdg.alloy4.XMLNode)) for `A4SolutionReader.read`, "_if there's a sig or field X in the XML but not in the list, then X (and its value in XML file) is added to the solution_". As a result, the error-prone file manipulation logic we use in order to get a `CompModule` from `parseEverything_fromFile` is not necessary.

Fixes #54.