### PR TITLE
Support using existing aliases to define new aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@ Specify the `-c` option to clear all aliases.
 Specify the `-l` option to list all current aliases.
 Specify the `-rm alias` option to remove an alias.
 
+An existing alias can be used in the definition of a new alias. To do so, wrap the existing alias in backticks when specifying the formula for the new alias.
+
+```
+(aldb) alias a 1
+(aldb) alias b `a`+1
+(aldb) alias -l
+
+Alias           Formula
+a               1
+b               1+1
+
+```
+
 #### alt
 The `alt [-r]` command switches between alternative execution paths in the current trace. Multiple unique states can be reached for a given path length; this command allows the user to explore all those states.
 

--- a/src/commands/AliasCommand.java
+++ b/src/commands/AliasCommand.java
@@ -13,6 +13,8 @@ public class AliasCommand extends Command {
     private final static String L_FLAG = "-l";
     private final static String C_FLAG = "-c";
 
+    private final static String ERROR_ADDING = "Error adding alias. Please ensure nested aliases are specified properly.";
+
     public String getName() {
         return CommandConstants.ALIAS_NAME;
     }
@@ -66,7 +68,10 @@ public class AliasCommand extends Command {
                     return;
                 }
                 formula = m.group(1).replace("\"", "");
-                am.addAlias(arg, formula);
+
+                if (!am.addAlias(arg, formula)) {
+                    System.out.println(ERROR_ADDING);
+                }
             }
         }
     }

--- a/src/simulation/AliasManager.java
+++ b/src/simulation/AliasManager.java
@@ -10,6 +10,7 @@ public class AliasManager {
     private Map<String, String> aliases;
     private final static String ALIAS_HEADER = "Alias";
     private final static String FORMULA_HEADER = "Formula";
+    private final static String BACKTICK = "`";
 
     public AliasManager() {
         aliases = new HashMap<>();
@@ -19,8 +20,13 @@ public class AliasManager {
         return aliases.containsKey(alias);
     }
 
-    public void addAlias(String alias, String formula) {
-        aliases.put(alias, formula);
+    public boolean addAlias(String alias, String formula) {
+        String resolvedFormula = resolveFormula(formula);
+        if (resolvedFormula == null || resolvedFormula.isEmpty()) {
+            return false;
+        }
+        aliases.put(alias, resolvedFormula);
+        return true;
     }
 
     public boolean removeAlias(String alias) {
@@ -42,5 +48,34 @@ public class AliasManager {
             sb.append(String.format("%-16s%s\n", alias, aliases.get(alias)));
         }
         return sb.toString();
+    }
+
+    private String resolveFormula(String formula) {
+        int l = -1;
+        StringBuilder resolved = new StringBuilder();
+        for (int i = 0; i < formula.length(); i++) {
+            String c = String.valueOf(formula.charAt(i));
+            if (c.equals(BACKTICK)) {
+                if (l == -1) {
+                    l = i;
+                } else {
+                    String nestedAlias = formula.substring(l + 1, i).trim();
+                    l = -1;
+                    if (nestedAlias.isEmpty()) {
+                        continue;
+                    }
+                    if (!isAlias(nestedAlias)) {
+                        return null;
+                    }
+                    resolved.append(getFormula(nestedAlias));
+                }
+            } else if (l == -1) {
+                resolved.append(c);
+            }
+        }
+        if (l != -1) {
+            return null;
+        }
+        return resolved.toString();
     }
 }

--- a/src/simulation/AliasManager.java
+++ b/src/simulation/AliasManager.java
@@ -10,7 +10,7 @@ public class AliasManager {
     private Map<String, String> aliases;
     private final static String ALIAS_HEADER = "Alias";
     private final static String FORMULA_HEADER = "Formula";
-    private final static String BACKTICK = "`";
+    private final static char NESTED_ALIAS_WRAPPER = '`';
 
     public AliasManager() {
         aliases = new HashMap<>();
@@ -54,8 +54,8 @@ public class AliasManager {
         int l = -1;
         StringBuilder resolved = new StringBuilder();
         for (int i = 0; i < formula.length(); i++) {
-            String c = String.valueOf(formula.charAt(i));
-            if (c.equals(BACKTICK)) {
+            char c = formula.charAt(i);
+            if (c == NESTED_ALIAS_WRAPPER) {
                 if (l == -1) {
                     l = i;
                 } else {

--- a/test/simulation/TestAliasManager.java
+++ b/test/simulation/TestAliasManager.java
@@ -14,13 +14,13 @@ public class TestAliasManager {
         String alias2 = "f2";
         String formula = "a=b";
 
-        am.addAlias(alias, formula);
+        assertTrue(am.addAlias(alias, formula));
         assertTrue(am.isAlias(alias));
         assertEquals(formula, am.getFormula(alias));
         assertEquals(null, am.getFormula(alias2));
         assertFalse(am.isAlias(alias2));
 
-        am.addAlias(alias2, formula);
+        assertTrue(am.addAlias(alias2, formula));
         assertTrue(am.isAlias(alias));
         assertTrue(am.isAlias(alias2));
         assertEquals(formula, am.getFormula(alias));
@@ -28,11 +28,66 @@ public class TestAliasManager {
 
         // Test overwriting.
         String formula2 = "c=d";
-        am.addAlias(alias2, formula2);
+        assertTrue(am.addAlias(alias2, formula2));
         assertTrue(am.isAlias(alias));
         assertTrue(am.isAlias(alias2));
         assertEquals(formula, am.getFormula(alias));
         assertEquals(formula2, am.getFormula(alias2));
+    }
+
+    @Test
+    public void testAddAlias_nested() {
+        AliasManager am = new AliasManager();
+
+        assertTrue(am.addAlias("a", "1"));
+        assertTrue(am.isAlias("a"));
+        assertEquals("1", am.getFormula("a"));
+
+        assertTrue(am.addAlias("b", "`a`+1"));
+        assertTrue(am.isAlias("b"));
+        assertEquals("1+1", am.getFormula("b"));
+
+        assertTrue(am.addAlias("c", "`a`+`b`+1"));
+        assertTrue(am.isAlias("c"));
+        assertEquals("1+1+1+1", am.getFormula("c"));
+
+        assertTrue(am.addAlias("d", "`a `+1"));
+        assertTrue(am.isAlias("d"));
+        assertEquals("1+1", am.getFormula("d"));
+
+        assertTrue(am.addAlias("e", "` a`+1"));
+        assertTrue(am.isAlias("e"));
+        assertEquals("1+1", am.getFormula("e"));
+
+        assertTrue(am.addAlias("f", "``+1"));
+        assertTrue(am.isAlias("f"));
+        assertEquals("+1", am.getFormula("f"));
+
+        assertTrue(am.addAlias("abcd", "2"));
+        assertTrue(am.isAlias("abcd"));
+        assertEquals("2", am.getFormula("abcd"));
+
+        assertTrue(am.addAlias("g", "`abcd`+1"));
+        assertTrue(am.isAlias("g"));
+        assertEquals("2+1", am.getFormula("g"));
+
+        assertTrue(am.addAlias("h", "1+`abcd`"));
+        assertTrue(am.isAlias("h"));
+        assertEquals("1+2", am.getFormula("h"));
+
+        assertTrue(am.addAlias("i", "`abcd`"));
+        assertTrue(am.isAlias("i"));
+        assertEquals("2", am.getFormula("i"));
+
+        assertFalse(am.addAlias("z", "`a``+1"));
+        assertFalse(am.isAlias("z"));
+
+        assertFalse(am.isAlias("foo"));
+        assertFalse(am.addAlias("z", "`foo`+1"));
+        assertFalse(am.isAlias("z"));
+
+        assertFalse(am.addAlias("z", "``"));
+        assertFalse(am.isAlias("z"));
     }
 
     @Test
@@ -42,7 +97,7 @@ public class TestAliasManager {
         String formula = "a=b";
 
         assertFalse(am.removeAlias(alias));
-        am.addAlias(alias, formula);
+        assertTrue(am.addAlias(alias, formula));
         assertTrue(am.removeAlias(alias));
         assertFalse(am.isAlias(alias));
         assertFalse(am.removeAlias(alias));
@@ -55,8 +110,8 @@ public class TestAliasManager {
         String alias2 = "f2";
         String formula = "a=b";
 
-        am.addAlias(alias, formula);
-        am.addAlias(alias2, formula);
+        assertTrue(am.addAlias(alias, formula));
+        assertTrue(am.addAlias(alias2, formula));
         am.clearAliases();
         assertFalse(am.isAlias(alias));
         assertFalse(am.isAlias(alias2));
@@ -69,8 +124,8 @@ public class TestAliasManager {
         String alias2 = "f2";
         String formula = "a=b";
 
-        am.addAlias(alias, formula);
-        am.addAlias(alias2, formula);
+        assertTrue(am.addAlias(alias, formula));
+        assertTrue(am.addAlias(alias2, formula));
         String expected = "\nAlias           Formula\nf1              a=b\nf2              a=b\n";
         assertEquals(expected, am.getFormattedAliases());
     }

--- a/test/simulation/TestAliasManager.java
+++ b/test/simulation/TestAliasManager.java
@@ -79,6 +79,12 @@ public class TestAliasManager {
         assertTrue(am.isAlias("i"));
         assertEquals("2", am.getFormula("i"));
 
+        // Removing an alias used in the definition of a newer alias should not affect the newer alias.
+        assertTrue(am.removeAlias("abcd"));
+        assertFalse(am.isAlias("abcd"));
+        assertTrue(am.isAlias("i"));
+        assertEquals("2", am.getFormula("i"));
+
         assertFalse(am.addAlias("z", "`a``+1"));
         assertFalse(am.isAlias("z"));
 


### PR DESCRIPTION
Example usage:

```
(aldb) alias a 1
(aldb) alias b `a`+1
(aldb) alias -l

Alias           Formula
a               1
b               1+1

(aldb) alias c `foo`+1
Error adding alias. Please ensure nested aliases are specified properly.
(aldb)
```

(See the new tests for other cases.)

Closes #56.